### PR TITLE
Feature: Lock Timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,14 @@ Fine-tune the alignment results visually.
 
 ### 3. Keyboard Shortcuts
 
-| Shortcut        | Action                                    |
-| :-------------- | :---------------------------------------- |
-| **Space**       | Play / Pause                              |
-| **Right Arrow** | Skip to next segment                      |
-| **Left Arrow**  | Skip to previous segment                  |
-| **Cmd + Right** | Nudge segment start **forward** (+0.15s)  |
-| **Cmd + Left**  | Nudge segment start **backward** (-0.15s) |
+| Shortcut        | Action                                                              |
+| :-------------- | :------------------------------------------------------------------ |
+| **Space**       | Play / Pause                                                        |
+| **Right Arrow** | Skip to next segment                                                |
+| **Left Arrow**  | Skip to previous segment                                            |
+| **Cmd + Right** | Nudge segment start **forward** (+0.15s)                            |
+| **Cmd + Left**  | Nudge segment start **backward** (-0.15s)                           |
+| **L**           | Lock / unlock the focused fragment's timing (pin). Requires a fragment to be focused (double-click a row in the list to focus it). |
 
 ### 4. Export Options
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,33 @@ dart run bin/isochron_cli.dart \
 *   `-a, --audio`: Path to input audio file.
 *   `-o, --output`: JSON output path (default: `alignment.json`).
 *   `--dict`: Path to a JSON file for character transliteration rules.
+*   `--pins`: Path to a JSON file containing known-correct timings for specific fragments (see below).
 *   `--ffmpeg` / `--espeak`: Custom paths to binaries (useful if they are not in your system PATH).
+
+**Pinned Timings (`--pins`):**
+
+If you have listened to the audio and verified that certain fragments are mis-aligned, you can lock those timestamps in and have the aligner re-compute everything else around them.
+
+Create a JSON file where each key is a **fragment index** (0-based, as a string) and each value is an object with `start` and `end` in seconds:
+
+```json
+{
+  "0": { "start": 0.0,  "end": 1.4  },
+  "7": { "start": 12.3, "end": 15.2 }
+}
+```
+
+Then pass it with `--pins`:
+
+```bash
+dart run bin/isochron_cli.dart \
+  --text transcript.txt \
+  --audio recording.mp3 \
+  --pins pins.json \
+  --output result.json
+```
+
+Pins do **not** need to be contiguous or in order — you can lock in the first and eighth fragment while leaving everything else to the automatic aligner. The pipeline splits the audio into segments between pins and runs a separate DTW pass in each window, so non-pinned fragments are constrained to exactly the real-audio range their surrounding pins define.
 
 ## Isochron Studio (Flutter App)
 

--- a/isochron_cli/bin/isochron_cli.dart
+++ b/isochron_cli/bin/isochron_cli.dart
@@ -16,6 +16,11 @@ void main(List<String> arguments) async {
         help: 'Path to espeak-ng binary', defaultsTo: 'espeak-ng')
     ..addOption('dict',
         help: 'Path to a JSON file containing transliteration rules')
+    ..addOption('pins',
+        help:
+            'Path to a JSON file containing known-correct timings for specific fragments. '
+            'Keys are fragment indices (0-based strings), values are objects with "start" and "end" in seconds. '
+            'Example: {"0":{"start":0.0,"end":1.4},"7":{"start":12.3,"end":15.2}}')
     ..addFlag('verbose',
         abbr: 'v', help: 'Show detailed logs', defaultsTo: false)
     ..addFlag('help',
@@ -33,12 +38,14 @@ void main(List<String> arguments) async {
     final textPath = results['text'];
     final audioPath = results['audio'];
     final dictPath = results['dict'];
+    final pinsPath = results['pins'];
     final outputJsonPath = results['output'];
     final ffmpegPath = results['ffmpeg'];
     final espeakPath = results['espeak'];
     // final transliterate = results['transliterate'] as bool;
     final verbose = results['verbose'] as bool;
     Map<String, String>? rules;
+    Map<int, ({double start, double end})>? pinnedTimings;
 
     if (textPath == null || audioPath == null) {
       stderr.writeln('Error: Both --text and --audio are required.');
@@ -65,6 +72,36 @@ void main(List<String> arguments) async {
       }
     }
 
+    if (pinsPath != null) {
+      if (verbose) print('Loading pinned timings from: $pinsPath');
+      final pinsFile = File(pinsPath);
+      if (!pinsFile.existsSync()) {
+        stderr.writeln('Error: Pins file not found: $pinsPath');
+        exit(1);
+      }
+      try {
+        final rawMap =
+            jsonDecode(await pinsFile.readAsString()) as Map<String, dynamic>;
+        pinnedTimings = {};
+        for (final entry in rawMap.entries) {
+          final idx = int.tryParse(entry.key);
+          if (idx == null) {
+            stderr.writeln(
+                'Warning: Skipping invalid pin key "${entry.key}" (must be an integer index).');
+            continue;
+          }
+          final obj = entry.value as Map<String, dynamic>;
+          final start = (obj['start'] as num).toDouble();
+          final end = (obj['end'] as num).toDouble();
+          pinnedTimings[idx] = (start: start, end: end);
+        }
+        if (verbose) print('Loaded ${pinnedTimings.length} pinned timing(s).');
+      } catch (e) {
+        stderr.writeln('Error: Invalid JSON format in pins file: $e');
+        exit(1);
+      }
+    }
+
     // --- Setup Workspace ---
     final workDir = Directory.systemTemp.createTempSync('isochron_cli_');
     if (verbose) print('Workspace: ${workDir.path}');
@@ -82,6 +119,7 @@ void main(List<String> arguments) async {
         ffmpegPath: ffmpegPath,
         espeakPath: espeakPath,
         transliterationRules: rules,
+        pinnedTimings: pinnedTimings,
       );
       // ---------------------
 

--- a/isochron_cli/lib/isochron_cli.dart
+++ b/isochron_cli/lib/isochron_cli.dart
@@ -8,6 +8,7 @@ export 'src/core/text_parser.dart';
 export 'src/core/time_projector.dart';
 export 'src/core/isochron_processor.dart';
 export 'src/core/transliterator.dart';
+export 'src/core/pin_boundary_enforcer.dart';
 
 // Math
 export 'src/math/dsp_utils.dart';

--- a/isochron_cli/lib/src/core/fragment.dart
+++ b/isochron_cli/lib/src/core/fragment.dart
@@ -21,6 +21,15 @@ class Fragment {
   double realStart = 0.0;
   double realEnd = 0.0;
 
+  // --- Pinned Timings (user-verified) ---
+  /// If set, these values were supplied by the user and are treated as ground truth.
+  /// The alignment pipeline will use these as hard boundaries rather than computing them.
+  double? pinnedStart;
+  double? pinnedEnd;
+
+  /// Returns true if the user has locked in the timing for this fragment.
+  bool get isPinned => pinnedStart != null;
+
   Fragment({
     required this.index,
     required this.text,
@@ -32,6 +41,13 @@ class Fragment {
   void setRealTiming({required double start, required double end}) {
     realStart = start;
     realEnd = end;
+  }
+
+  /// Locks in user-verified timing so the pipeline treats this fragment as a
+  /// fixed boundary rather than aligning it via DTW.
+  void setPinnedTiming({required double start, required double end}) {
+    pinnedStart = start;
+    pinnedEnd = end;
   }
 
   /// Helper to update anchor timing during synthesis

--- a/isochron_cli/lib/src/core/fragment.dart
+++ b/isochron_cli/lib/src/core/fragment.dart
@@ -50,6 +50,12 @@ class Fragment {
     pinnedEnd = end;
   }
 
+  /// Removes the pin, returning this fragment to normal DTW-aligned status.
+  void clearPinnedTiming() {
+    pinnedStart = null;
+    pinnedEnd = null;
+  }
+
   /// Helper to update anchor timing during synthesis
   void setAnchorTiming({required double start, required double end}) {
     anchorStart = start;

--- a/isochron_cli/lib/src/core/isochron_processor.dart
+++ b/isochron_cli/lib/src/core/isochron_processor.dart
@@ -24,6 +24,11 @@ class IsochronProcessor {
     String espeakPath = 'espeak-ng',
     Map<String, String>? transliterationRules,
     ProgressCallback? onProgress,
+
+    /// Optional map of fragment index → known-correct {start, end} in seconds.
+    /// Pinned fragments are used as hard boundaries; all other fragments are
+    /// aligned via DTW within the windows that pins define.
+    Map<int, ({double start, double end})>? pinnedTimings,
   }) async {
     onProgress?.call("Parsing Text...", 0.05);
     final fragments = TextParser.parse(text);
@@ -85,20 +90,105 @@ class IsochronProcessor {
       },
     );
 
-    // Alignment
-    final path =
-        DtwAligner.align(userMfcc, anchorMfcc, onProgress: (status, pct) {
-      // Map 0.0-1.0 to 0.45-0.95
-      final overall = 0.45 + (pct * 0.50);
-      onProgress?.call(status, overall);
-    });
-
-    // Projection
-    onProgress?.call("Finalizing...", 0.95);
-    TimeProjector.project(fragments, path);
-
-    onProgress?.call("Refining Timestamps...", 0.98);
+    const double frameStride = 0.010;
     final audioBytes = _readWavData(userAudioWav);
+
+    if (pinnedTimings == null || pinnedTimings.isEmpty) {
+      // ── Original single-pass path ──────────────────────────────────────────
+      final path =
+          DtwAligner.align(userMfcc, anchorMfcc, onProgress: (status, pct) {
+        final overall = 0.45 + (pct * 0.50);
+        onProgress?.call(status, overall);
+      });
+      onProgress?.call('Finalizing...', 0.95);
+      TimeProjector.project(fragments, path);
+    } else {
+      // ── Segmented DTW: one DTW pass per gap between pinned fragments ────────
+      //
+      // 1. Stamp each pinned fragment with its user-provided times.
+      for (final entry in pinnedTimings.entries) {
+        final idx = entry.key;
+        if (idx >= 0 && idx < fragments.length) {
+          fragments[idx]
+              .setPinnedTiming(start: entry.value.start, end: entry.value.end);
+        }
+      }
+
+      // 2. Build the ordered list of boundary indices.
+      //    Sentinel -1 represents "before the first fragment" and
+      //    fragments.length represents "after the last fragment".
+      final sortedPins = (pinnedTimings.keys.toList()..sort());
+      final boundaries = <int>[-1, ...sortedPins, fragments.length];
+
+      onProgress?.call('Aligning segments...', 0.45);
+
+      // 3. For each gap between consecutive boundaries, run a scoped DTW.
+      for (int b = 0; b < boundaries.length - 1; b++) {
+        final prevPin = boundaries[b]; // -1 or a pinned fragment index
+        final nextPin = boundaries[b + 1]; // pinned fragment index or length
+
+        // The unaligned fragments live strictly between the two pins.
+        final segFragStart = prevPin + 1;
+        final segFragEnd = nextPin - 1; // inclusive
+        if (segFragStart > segFragEnd) continue; // nothing between these pins
+
+        // Real-audio frame window.
+        final int realFrameStart = prevPin == -1
+            ? 0
+            : (fragments[prevPin].pinnedEnd! / frameStride).round();
+        final int realFrameEnd = nextPin == fragments.length
+            ? userMfcc.length
+            : (fragments[nextPin].pinnedStart! / frameStride).round();
+
+        // Anchor frame window.
+        final int anchorFrameStart = prevPin == -1
+            ? 0
+            : (fragments[prevPin].anchorEnd / frameStride).round();
+        final int anchorFrameEnd = nextPin == fragments.length
+            ? anchorMfcc.length
+            : (fragments[nextPin].anchorStart / frameStride).round();
+
+        // Guard against degenerate slices.
+        if (realFrameStart >= realFrameEnd ||
+            anchorFrameStart >= anchorFrameEnd) {
+          continue;
+        }
+
+        final realSlice = userMfcc.sublist(
+            realFrameStart, realFrameEnd.clamp(0, userMfcc.length));
+        final anchorSlice = anchorMfcc.sublist(
+            anchorFrameStart, anchorFrameEnd.clamp(0, anchorMfcc.length));
+        if (realSlice.isEmpty || anchorSlice.isEmpty) {
+          continue;
+        }
+
+        // Run DTW on the slice; indices are relative to slice start (0-based).
+        final relativePath = DtwAligner.align(realSlice, anchorSlice);
+
+        // Offset path back to absolute frame indices before projecting.
+        final offsetPath = relativePath
+            .map((p) => AlignmentPoint(
+                  p.realIndex + realFrameStart,
+                  p.anchorIndex + anchorFrameStart,
+                ))
+            .toList();
+
+        final segFragments = fragments.sublist(segFragStart, segFragEnd + 1);
+        TimeProjector.project(segFragments, offsetPath,
+            frameStride: frameStride);
+      }
+
+      // 4. Apply pinned timings directly — these override anything DTW set.
+      for (final frag in fragments) {
+        if (frag.isPinned) {
+          frag.setRealTiming(start: frag.pinnedStart!, end: frag.pinnedEnd!);
+        }
+      }
+
+      onProgress?.call('Finalizing...', 0.95);
+    }
+
+    onProgress?.call('Refining Timestamps...', 0.98);
     BoundarySnapper.snap(fragments, audioBytes, 16000);
 
     onProgress?.call("Done", 1.0);

--- a/isochron_cli/lib/src/core/isochron_processor.dart
+++ b/isochron_cli/lib/src/core/isochron_processor.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import '../core/fragment.dart';
 import '../core/text_parser.dart';
 import '../core/time_projector.dart';
+import '../core/pin_boundary_enforcer.dart';
 import '../synthesis/anchor_generator.dart';
 import '../math/mfcc_extractor.dart';
 import '../math/dtw_aligner.dart';
@@ -190,6 +191,13 @@ class IsochronProcessor {
 
     onProgress?.call('Refining Timestamps...', 0.98);
     BoundarySnapper.snap(fragments, audioBytes, 16000);
+
+    // When pins are present, re-enforce boundaries after snapping.
+    // BoundarySnapper can advance a start past a pin boundary (gap) or
+    // DTW can leave an end inside the next pin's window (overlap).
+    if (pinnedTimings != null && pinnedTimings.isNotEmpty) {
+      PinBoundaryEnforcer.enforce(fragments);
+    }
 
     onProgress?.call("Done", 1.0);
     return fragments;

--- a/isochron_cli/lib/src/core/pin_boundary_enforcer.dart
+++ b/isochron_cli/lib/src/core/pin_boundary_enforcer.dart
@@ -1,0 +1,63 @@
+import 'fragment.dart';
+
+/// Applies a post-processing pass to ensure fragment timings respect pin
+/// boundaries with no gaps or overlaps.
+///
+/// This runs after [BoundarySnapper] because the energy-onset snapper can
+/// advance a fragment's start past a pin boundary (creating a gap) or DTW
+/// can land a fragment slightly inside an adjacent pin's window (creating an
+/// overlap).
+///
+/// **Forward pass (left → right):**
+/// - If fragment[i-1] is pinned, fragment[i].realStart is set to
+///   fragment[i-1].realEnd (eliminates the gap that snapping can introduce
+///   after a pin).
+/// - If fragment[i].realStart < fragment[i-1].realEnd (any overlap with the
+///   previous fragment), fragment[i].realStart is advanced to fix it.
+///
+/// **Backward pass (right → left):**
+/// - If fragment[i+1] is pinned, fragment[i].realEnd is set to
+///   fragment[i+1].realStart (eliminates overlaps that DTW can create before
+///   a pin).
+/// - If fragment[i].realEnd > fragment[i+1].realStart (any overlap into the
+///   next fragment), fragment[i].realEnd is pulled back to fix it.
+///
+/// Pinned fragments themselves are never moved.
+class PinBoundaryEnforcer {
+  /// Enforce pin boundaries on [fragments] in-place.
+  ///
+  /// Assumes [fragments] are in ascending index order and already have
+  /// [Fragment.realStart] / [Fragment.realEnd] set for every fragment.
+  static void enforce(List<Fragment> fragments) {
+    if (fragments.length < 2) return;
+
+    // ── Forward pass ─────────────────────────────────────────────────────────
+    // After a pinned fragment: always chain the next fragment's start to the
+    // pin's end (no gap). For non-pinned→non-pinned: only fix actual overlaps.
+    for (int i = 1; i < fragments.length; i++) {
+      if (fragments[i].isPinned) continue;
+      final prevEnd = fragments[i - 1].realEnd;
+      if (fragments[i - 1].isPinned || fragments[i].realStart < prevEnd) {
+        fragments[i].realStart = prevEnd;
+      }
+    }
+
+    // ── Backward pass ─────────────────────────────────────────────────────────
+    // Before a pinned fragment: always chain the previous fragment's end to the
+    // pin's start (no gap or overlap). For non-pinned→non-pinned: only fix
+    // actual overlaps.
+    for (int i = fragments.length - 2; i >= 0; i--) {
+      if (fragments[i].isPinned) continue;
+      final nextStart = fragments[i + 1].realStart;
+      if (fragments[i + 1].isPinned || fragments[i].realEnd > nextStart) {
+        fragments[i].realEnd = nextStart;
+      }
+
+      // Guard: realEnd must never be less than realStart (possible when a
+      // very narrow window is squeezed between two close pins).
+      if (fragments[i].realEnd < fragments[i].realStart) {
+        fragments[i].realEnd = fragments[i].realStart;
+      }
+    }
+  }
+}

--- a/isochron_cli/lib/src/math/boundary_snapper.dart
+++ b/isochron_cli/lib/src/math/boundary_snapper.dart
@@ -19,6 +19,9 @@ class BoundarySnapper {
     noiseFloor = (noiseFloor / noiseSamples) * 1.5; // 1.5x average noise
 
     for (final frag in fragments) {
+      // Skip fragments whose timings were user-verified — don't move them.
+      if (frag.isPinned) continue;
+
       // 1. Snap Start Time
       int originalStartIndex = (frag.realStart * sampleRate).round();
       int searchStart = max(0, originalStartIndex - windowSamples);

--- a/isochron_cli/technical_overview.md
+++ b/isochron_cli/technical_overview.md
@@ -1,0 +1,356 @@
+# Isochron CLI — Technical Overview
+### How Text Transcripts Are Aligned with Audio Recordings
+
+---
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Key Terms & Definitions](#key-terms--definitions)
+3. [The Big Picture: A 7-Step Pipeline](#the-big-picture-a-7-step-pipeline)
+4. [Step 1 — Parse the Text](#step-1--parse-the-text)
+5. [Step 2 — Transliteration (Optional)](#step-2--transliteration-optional)
+6. [Step 3 — Generate Anchor Audio (TTS)](#step-3--generate-anchor-audio-tts)
+7. [Step 4 — Normalize the User's Audio](#step-4--normalize-the-users-audio)
+8. [Step 5 — MFCC Feature Extraction](#step-5--mfcc-feature-extraction)
+9. [Step 6 — DTW Alignment](#step-6--dtw-alignment)
+10. [Step 7 — Time Projection & Boundary Snapping](#step-7--time-projection--boundary-snapping)
+11. [Output Format](#output-format)
+12. [File Reference Summary](#file-reference-summary)
+
+---
+
+## Overview
+
+Isochron CLI takes two inputs:
+
+- **A text file** — a transcript, split into lines (one line = one "fragment").
+- **An audio file** — a real human reading that same transcript aloud.
+
+It produces a **JSON output** where every line of text is tagged with a precise start and end time in the audio. This is called **forced alignment**.
+
+The core challenge is: the human's recording does not have a built-in clock that says "word X starts at 2.3 seconds." The system must *figure out* those timestamps by comparing the human's voice against a computer-generated reference version of the same text.
+
+---
+
+## Key Terms & Definitions
+
+| Term | Plain-English Definition |
+|------|--------------------------|
+| **Fragment** | One line of text from the input file. Each fragment will eventually get a start and end time. |
+| **Anchor Audio** | A computer-generated (TTS) recording of the text. It acts as a perfect reference with known timings. |
+| **Sample Rate (16 kHz)** | Audio is stored as a sequence of numbers (samples). 16,000 samples per second (16 kHz) is CD-quality for speech. |
+| **Frame** | A tiny slice of audio — in this code, 20 milliseconds long. Feature extraction happens one frame at a time. |
+| **Frame Stride** | How much we slide the frame forward for the next slice — 10 ms here. Frames *overlap*, which gives smoother results. |
+| **FFT (Fast Fourier Transform)** | A mathematical trick that converts a time-based audio signal into a list of frequencies and their strengths — like decomposing white light into a rainbow. |
+| **Power Spectrum** | The output of an FFT, showing how much energy is present at each frequency. |
+| **Mel Scale** | A way of measuring frequency that mirrors how human ears work. High frequencies (e.g. 8000 Hz vs 8100 Hz) are harder for humans to distinguish than low ones (100 Hz vs 200 Hz). The Mel scale "squishes" high frequencies together. |
+| **Mel Filterbank** | A set of triangular "buckets" spread across the Mel scale that group nearby frequencies together, producing a more human-like frequency summary. |
+| **MFCC** | Mel-Frequency Cepstral Coefficients — a compact 13-number "fingerprint" for each 20ms slice of audio. Used to represent *what a sound sounds like* in a way that's easy to compare. |
+| **DCT (Discrete Cosine Transform)** | A compression step that converts 26 filterbank energies into 13 independent coefficients, removing redundant information. |
+| **DTW (Dynamic Time Warping)** | An algorithm that compares two sequences of different lengths or speeds by finding the best "elastic" match between them. Like stretching/squishing one sequence until it best fits the other. |
+| **Alignment Path** | The output of DTW — a list of pairs `(realFrame, anchorFrame)` that says "frame 42 of the human audio matches frame 38 of the anchor audio." |
+| **Boundary Snapping** | A refinement step that micro-adjusts timestamps to align with actual energy onsets in the audio rather than relying purely on DTW math. |
+| **Transliteration** | Converting text written in one alphabet into its phonetic equivalent in another. For example, converting Greek "Αθήνα" into the Latin-script pronunciation "Athena" so eSpeak can read it correctly. |
+| **TTS (Text-to-Speech)** | Software that converts written text into spoken audio. This code uses **eSpeak-ng**. |
+| **FFmpeg** | A widely-used command-line tool for converting and processing audio/video files. Used here to normalize audio to a consistent format. |
+
+---
+
+## The Big Picture: A 7-Step Pipeline
+
+```
+[Text File]  ──→  1. Parse Text  ──→  Fragments[]
+                                         │
+                                    2. Transliterate (optional)
+                                         │
+                                    3. Generate Anchor Audio (eSpeak TTS)
+                                         │                       │
+                                    4. Normalize User Audio  anchor timings
+                                         │                       │
+                                    5. MFCC Extraction ──────────┘
+                                      (both audio files)
+                                         │
+                                    6. DTW Alignment
+                                         │
+                                    7. Time Projection + Boundary Snapping
+                                         │
+                                    [alignment.json]
+```
+
+The key insight is the **anchor strategy**: instead of trying to directly analyze the human's voice and guess where each word starts, the system creates a perfect synthetic reference. It then uses DTW to find how the human recording "stretches" or "compresses" relative to that perfect reference.
+
+---
+
+## Step 1 — Parse the Text
+
+**File:** `isochron_cli/lib/src/core/text_parser.dart`
+
+The text file is split into lines. Each non-empty line becomes a **Fragment** object.
+
+```dart
+// From text_parser.dart
+final lines = rawText.split(RegExp(r'\r?\n'));
+fragments.add(Fragment(index: counter, text: cleanLine));
+```
+
+**Fragment** (`isochron_cli/lib/src/core/fragment.dart`) is the central data structure. It holds:
+- `text` — the original line of text
+- `spokenText` — a transliterated version (if needed)
+- `anchorStart` / `anchorEnd` — timings in the synthetic audio
+- `realStart` / `realEnd` — final timings in the human audio (the goal!)
+
+---
+
+## Step 2 — Transliteration (Optional)
+
+**File:** `isochron_cli/lib/src/core/transliterator.dart`
+
+If the text uses a non-Latin alphabet (e.g. Greek, Arabic), eSpeak may struggle to pronounce it correctly. The user can provide a **dictionary file** (a JSON map of character substitutions) via the `--dict` flag.
+
+```json
+{ "α": "a", "β": "v", "ñ": "ny" }
+```
+
+The `Transliterator` applies these rules character by character, with three priority levels:
+
+1. **Direct match** — exact character found in the dictionary → use the mapped value.
+2. **Decompose + strip** — if a character like "ά" isn't in the dictionary, it decomposes it to "α" + a diacritic mark, then strips the mark.
+3. **Base mapping** — checks if the stripped base character ("α") is in the dictionary.
+4. **Fallback** — if nothing matches, just keep the stripped character as-is.
+
+The result is stored in `frag.spokenText` and used by eSpeak instead of the original text.
+
+---
+
+## Step 3 — Generate Anchor Audio (TTS)
+
+**File:** `isochron_cli/lib/src/synthesis/anchor_generator.dart`
+
+For each fragment, **eSpeak-ng** generates a WAV audio clip of the spoken text. These clips are then normalized by FFmpeg to a consistent format (16 kHz, mono, 16-bit PCM) and concatenated into one long **anchor audio file**.
+
+As the clips are concatenated, the code tracks how many seconds each fragment occupies in the anchor audio:
+
+```dart
+// From anchor_generator.dart
+frag.setAnchorTiming(start: currentTime, end: currentTime + duration);
+currentTime += duration;
+```
+
+**Why is this important?** After DTW alignment, these anchor timings become our "rulers." We know that fragment #3 spans seconds 4.2–6.8 in the anchor — and DTW tells us what those anchor frames correspond to in the real audio.
+
+---
+
+## Step 4 — Normalize the User's Audio
+
+**File:** `isochron_cli/lib/src/core/isochron_processor.dart` (lines 50–67)
+
+Before feature extraction, the human's audio is converted to the same format as the anchor — mono, 16 kHz, 16-bit PCM — using FFmpeg:
+
+```
+ffmpeg -i user_audio.mp3 -ac 1 -ar 16000 -acodec pcm_s16le user_mono_16k.wav
+```
+
+This normalization is critical. If the two audio files had different sample rates or formats, comparing them would be like comparing a photo taken at 72 DPI with one taken at 300 DPI.
+
+---
+
+## Step 5 — MFCC Feature Extraction
+
+**File:** `isochron_cli/lib/src/math/mfcc_extractor.dart`  
+**Support file:** `isochron_cli/lib/src/math/dsp_utils.dart`
+
+This is the most technically involved step. It converts each audio file from a raw waveform into a **sequence of 13-number fingerprints** — one fingerprint per 10ms of audio.
+
+### Why MFCC?
+
+You can't directly compare two audio waveforms by subtraction — the same word spoken by two people looks completely different as raw samples. MFCC captures *how the vocal tract is shaped* when making a sound, which is consistent across speakers. Think of it like capturing the "shape" of a sound rather than the exact vibration pattern.
+
+### The Steps (for each 20ms frame):
+
+#### A. Pre-Emphasis
+```dart
+signal[i] = signal[i] - 0.97 * signal[i - 1];
+```
+Boosts high frequencies to compensate for the natural tendency of speech to have less energy at high frequencies. Think of it as a treble boost on an equalizer.
+
+#### B. Windowing (Hamming Window)
+Each 20ms frame is multiplied by a **Hamming window** — a bell-shaped curve that tapers the edges of the frame to zero. Without this, the hard edges of the frame would introduce artificial high-frequency noise in the FFT.
+
+```
+Before:  [0.2, 0.5, 0.8, 0.6, 0.3, 0.1]   ← hard cut at edges
+Window:  [0.1, 0.5, 0.9, 0.9, 0.5, 0.1]   ← bell shape
+After:   [0.02, 0.25, 0.72, 0.54, 0.15, 0.01]  ← smooth edges
+```
+
+#### C. FFT — Convert to Frequencies
+The windowed frame is passed through an FFT, which produces a **power spectrum** — essentially: "at 300 Hz, there's this much energy; at 1000 Hz, there's this much energy..."
+
+A 512-sample FFT gives us 256 frequency bins.
+
+#### D. Mel Filterbank
+The 256 frequency bins are grouped into **26 Mel-scale buckets** using triangular filters. This mimics how the human ear groups nearby frequencies at high pitches.
+
+**Example (simplified):**
+```
+Frequency bins:  [100Hz] [200Hz] [300Hz] ... [8000Hz]
+                   ↓ triangular filters ↓
+Mel buckets:     [bucket1] [bucket2] ... [bucket26]
+```
+
+The triangular filters overlap: a frequency of 450 Hz might contribute to both bucket 4 and bucket 5, with different weights (like a crossfade).
+
+#### E. Logarithm
+The energy in each of the 26 Mel buckets is passed through `log()`. This mirrors the way human hearing perceives loudness — doubling the sound energy doesn't sound twice as loud to us; it sounds slightly louder. Log scaling captures this perceptual reality.
+
+#### F. DCT — Compress to 13 Numbers
+The 26 log-Mel energies are transformed by a **Discrete Cosine Transform (DCT)** into 26 coefficients, and only the first **13** are kept. These 13 numbers are the MFCC vector for this frame.
+
+The DCT decorrelates the energies (removes redundancy between adjacent buckets) and compresses the most important information into the first few coefficients — similar to how JPEG compression works for images.
+
+**Result:** For a 10-second audio clip at 16 kHz, you end up with roughly 1,000 frames × 13 numbers each. This "matrix" is what DTW operates on.
+
+---
+
+## Step 6 — DTW Alignment
+
+**File:** `isochron_cli/lib/src/math/dtw_aligner.dart`  
+**Support file:** `isochron_cli/lib/src/math/vector_utils.dart`
+
+### What Is DTW?
+
+Imagine you have two sequences of frames:
+- **Anchor MFCC** — the synthetic voice (say, 900 frames)
+- **Real MFCC** — the human voice (say, 1100 frames — the human spoke more slowly)
+
+Simple frame-by-frame comparison would fail because the two sequences are different lengths. DTW finds the optimal "elastic" mapping between them.
+
+**Analogy:** Imagine two people clapping to the same song, but one person claps slightly faster in some parts and slower in others. DTW finds which clap from person A corresponds to which clap from person B.
+
+### How DTW Works
+
+DTW builds a matrix where each cell `(i, j)` represents "how well does frame `i` of the real audio match frame `j` of the anchor audio?"
+
+The cost of being at `(i, j)` = distance between the two MFCC vectors + the minimum cost to reach this cell from the three possible predecessors:
+
+```
+(i-1, j-1) ← diagonal  = both sequences advance together  (best match)
+(i-1, j)   ← up        = real audio has an extra frame (human spoke slowly)
+(i, j-1)   ← left      = anchor has an extra frame (human spoke quickly)
+```
+
+**Example grid (simplified, 4×4):**
+
+```
+         anchor0  anchor1  anchor2  anchor3
+real0  [  0.1     inf      inf      inf   ]
+real1  [  0.3     0.2      inf      inf   ]
+real2  [  0.8     0.3      0.15     inf   ]
+real3  [  inf     0.9      0.20     0.18  ]
+```
+
+The algorithm fills this grid from top-left to bottom-right, then **backtracks** from bottom-right to top-left to find the lowest-cost path. This path is the alignment.
+
+### Memory Optimization: Sliding Window
+
+A full N×M matrix for long audio would require gigabytes of RAM. The code uses a **band constraint** (radius = 500 frames ≈ 15 seconds): only cells within 500 frames of the diagonal are computed. This cuts memory from O(N×M) to O(N×radius).
+
+```dart
+// From dtw_aligner.dart
+final int r = max(radius, lengthDiff + 10);   // minimum radius to span length difference
+final int jCenter = (i * M / N).round();       // expected diagonal position for row i
+final int jStart = max(1, jCenter - r);
+final int jEnd   = min(M - 1, jCenter + r);
+```
+
+### Output: The Alignment Path
+
+The result is a list of `AlignmentPoint` objects:
+
+```dart
+class AlignmentPoint {
+  final int realIndex;    // frame index in human audio
+  final int anchorIndex;  // frame index in anchor audio
+}
+```
+
+Example path output (simplified):
+```
+(realFrame=0,  anchorFrame=0)
+(realFrame=1,  anchorFrame=1)
+(realFrame=2,  anchorFrame=1)   ← human spoke this sound slightly slower
+(realFrame=3,  anchorFrame=2)
+(realFrame=4,  anchorFrame=3)
+...
+```
+
+---
+
+## Step 7 — Time Projection & Boundary Snapping
+
+### Time Projection
+**File:** `isochron_cli/lib/src/core/time_projector.dart`
+
+Now the alignment path is used to convert anchor timestamps into real timestamps.
+
+Recall from Step 3: we know fragment #5 spans `anchorStart=4.2s` to `anchorEnd=6.8s` in the synthetic audio. We convert those times to frame numbers, then walk the alignment path to find the corresponding real audio frame numbers.
+
+```dart
+// From time_projector.dart
+final anchorStartFrame = (frag.anchorStart / frameStride).round();
+// Walk path until path[pathIndex].anchorIndex >= anchorStartFrame
+final realStart = path[startPoint].realIndex * frameStride;
+```
+
+Since each frame is 10ms (`frameStride = 0.010`), multiplying frame number × 0.010 gives time in seconds.
+
+### Boundary Snapping
+**File:** `isochron_cli/lib/src/math/boundary_snapper.dart`
+
+DTW gives good approximate timestamps, but they may be off by a few tens of milliseconds. The snapper refines the start time of each fragment by looking at the actual audio energy in a ±250ms window around the projected start time, and finding the exact moment the audio energy jumps above the background noise level.
+
+```dart
+// From boundary_snapper.dart
+if (localEnergy > noiseFloor) {
+  bestIndex = i;
+  break; // Found the onset!
+}
+```
+
+The noise floor is estimated from the first 0.5 seconds of the audio and multiplied by 1.5 to give a comfortable threshold above silence.
+
+---
+
+## Output Format
+
+The final JSON output contains one object per fragment:
+
+```json
+[
+  { "index": 0, "text": "In the beginning", "start": 0.240, "end": 1.850 },
+  { "index": 1, "text": "was the word",     "start": 1.860, "end": 3.120 },
+  { "index": 2, "text": "and the word",     "start": 3.130, "end": 4.200 }
+]
+```
+
+- `start` / `end` — timestamps in seconds, rounded to 3 decimal places.
+- `id` — included if the input text contained an explicit identifier.
+
+---
+
+## File Reference Summary
+
+| File | Role |
+|------|------|
+| `bin/isochron_cli.dart` | CLI entry point. Parses command-line flags, loads the dict file, calls `IsochronProcessor.process()`, and writes the JSON output. |
+| `lib/src/core/isochron_processor.dart` | **Master pipeline** — orchestrates all 7 steps in order. The best place to understand the full flow. |
+| `lib/src/core/fragment.dart` | The `Fragment` data class. Carries text, anchor timings, and real timings through the entire pipeline. |
+| `lib/src/core/text_parser.dart` | Splits the raw text file into `Fragment` objects (one per non-empty line). |
+| `lib/src/core/transliterator.dart` | Converts non-Latin characters to Latin equivalents using a user-provided dictionary. |
+| `lib/src/synthesis/anchor_generator.dart` | Calls eSpeak-ng to synthesize audio for each fragment, normalizes with FFmpeg, concatenates into one anchor WAV, and records anchor timings. |
+| `lib/src/math/mfcc_extractor.dart` | Converts raw WAV samples into MFCC feature vectors (13 numbers per 10ms frame). The core audio fingerprinting logic. |
+| `lib/src/math/dsp_utils.dart` | Mathematical helpers: `hzToMel`, `melToHz`, `createHammingWindow`, `dct`. |
+| `lib/src/math/dtw_aligner.dart` | Runs Dynamic Time Warping between real and anchor MFCC sequences. Returns the alignment path. |
+| `lib/src/math/vector_utils.dart` | `euclideanDistance` — measures how "different" two MFCC vectors are. |
+| `lib/src/core/time_projector.dart` | Uses the DTW path to convert anchor frame indices → real timestamps for each fragment. |
+| `lib/src/math/boundary_snapper.dart` | Refines start timestamps by detecting energy onsets in the real audio around each projected start time. |
+| `lib/src/audio/wav_utils.dart` | Calculates the duration of a WAV file from its byte size (assumes 16kHz/mono/16-bit format). |

--- a/isochron_cli/test/core/pin_boundary_enforcer_test.dart
+++ b/isochron_cli/test/core/pin_boundary_enforcer_test.dart
@@ -1,0 +1,197 @@
+import 'package:test/test.dart';
+import 'package:isochron_cli/isochron_cli.dart';
+
+/// Helper: build a Fragment with realStart/realEnd already set.
+Fragment _frag(int index, double start, double end) {
+  return Fragment(index: index, text: 'frag$index')
+    ..setRealTiming(start: start, end: end);
+}
+
+/// Helper: build a pinned Fragment.
+Fragment _pinned(int index, double start, double end) {
+  final f = Fragment(index: index, text: 'frag$index')
+    ..setAnchorTiming(start: 0, end: 0) // irrelevant for these tests
+    ..setRealTiming(start: start, end: end);
+  f.setPinnedTiming(start: start, end: end);
+  return f;
+}
+
+void main() {
+  group('PinBoundaryEnforcer', () {
+    // ── Exact reproduction of the reported demo bugs ──────────────────────────
+
+    test(
+        'gap after a pin: start of next fragment is advanced to pin end '
+        '(reproduces fragment 1 starting at 7.216 after pin ending at 7.0)',
+        () {
+      final frags = [
+        _pinned(0, 0.0, 7.0), //  pin: 0.0 – 7.0
+        _frag(1, 7.216, 11.99), // BoundarySnapper moved start to 7.216
+        _pinned(2, 12.0, 18.1), //  pin: 12.0 – 18.1
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      // Fragment 1 start must be clamped to pin 0's end.
+      expect(frags[1].realStart, closeTo(7.0, 0.001));
+      // Fragment 1's end must be clamped to pin 2's start.
+      expect(frags[1].realEnd, closeTo(12.0, 0.001));
+      // Pins are untouched.
+      expect(frags[0].realStart, closeTo(0.0, 0.001));
+      expect(frags[0].realEnd, closeTo(7.0, 0.001));
+      expect(frags[2].realStart, closeTo(12.0, 0.001));
+      expect(frags[2].realEnd, closeTo(18.1, 0.001));
+    });
+
+    test(
+        'overlap before a pin: end of previous fragment is pulled to pin start '
+        '(reproduces fragment 3 starting at 17.999 before pin ending at 18.1)',
+        () {
+      final frags = [
+        _pinned(2, 12.0, 18.1), // pin
+        _frag(3, 17.999, 27.95), // DTW landed inside pin 2's range
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      // Fragment 3 start must be clamped to pin 2's end.
+      expect(frags[1].realStart, closeTo(18.1, 0.001));
+      // Fragment 3's end is unchanged (nothing to its right).
+      expect(frags[1].realEnd, closeTo(27.95, 0.001));
+    });
+
+    // ── Properties after enforcement ─────────────────────────────────────────
+
+    test('pinned fragments are never modified', () {
+      final frags = [
+        _frag(0, 0.0, 3.0),
+        _pinned(1, 4.0, 6.0), // gap on left, will be exposed
+        _frag(2, 5.5, 9.0), // overlap on right
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      expect(frags[1].realStart, closeTo(4.0, 0.001));
+      expect(frags[1].realEnd, closeTo(6.0, 0.001));
+    });
+
+    test('non-pinned overlap (no pins involved) is fixed', () {
+      final frags = [
+        _frag(0, 0.0, 5.0),
+        _frag(1, 4.5, 9.0), // 4.5 < 5.0 → overlap
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      expect(frags[1].realStart, closeTo(5.0, 0.001));
+    });
+
+    test('non-pinned gap (no pins involved) is preserved', () {
+      // Gaps between non-pinned fragments are intentional (silence between
+      // segments); the enforcer only fills gaps caused by pin boundaries.
+      final frags = [
+        _frag(0, 0.0, 4.0),
+        _frag(1, 4.8, 9.0), // 4.8 > 4.0 → gap, not an overlap
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      expect(frags[1].realStart, closeTo(4.8, 0.001)); // unchanged
+    });
+
+    test('output is monotonically ordered with multiple pins', () {
+      final frags = [
+        _pinned(0, 0.0, 3.0),
+        _frag(1, 3.5, 5.9), // gap after pin 0; gap before pin 2
+        _pinned(2, 6.0, 7.0),
+        _frag(3, 6.8, 10.0), // overlap with pin 2
+        _frag(4, 9.0, 12.0), // overlap with fragment 3 after fix
+        _pinned(5, 11.5, 13.0),
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      // All starts and ends should be in non-decreasing order.
+      for (int i = 0; i < frags.length; i++) {
+        expect(frags[i].realStart, lessThanOrEqualTo(frags[i].realEnd + 0.0001),
+            reason: 'fragment $i: realStart must be <= realEnd');
+        if (i > 0) {
+          expect(frags[i].realStart,
+              greaterThanOrEqualTo(frags[i - 1].realEnd - 0.0001),
+              reason:
+                  'fragment $i: realStart must be >= previous fragment realEnd');
+        }
+      }
+
+      // Spot-checks.
+      expect(frags[1].realStart, closeTo(3.0, 0.001)); // chained to pin 0 end
+      expect(frags[1].realEnd, closeTo(6.0, 0.001)); // chained to pin 2 start
+      expect(frags[3].realStart, closeTo(7.0, 0.001)); // chained to pin 2 end
+    });
+
+    test(
+        'degenerate: window squeezed to zero by adjacent pins never inverts '
+        'realStart / realEnd', () {
+      // Pin 0 ends at 5.0, pin 1 starts at 5.0 — zero-width window.
+      final frags = [
+        _pinned(0, 0.0, 5.0),
+        _frag(1, 4.8, 5.2), // squeezed between two pins
+        _pinned(2, 5.0, 8.0),
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      // Neither realStart nor realEnd should exceed the other.
+      expect(frags[1].realStart, lessThanOrEqualTo(frags[1].realEnd + 0.0001));
+    });
+
+    test('single fragment list is a no-op', () {
+      final frags = [_frag(0, 1.0, 3.0)];
+      PinBoundaryEnforcer.enforce(frags);
+      expect(frags[0].realStart, closeTo(1.0, 0.001));
+      expect(frags[0].realEnd, closeTo(3.0, 0.001));
+    });
+
+    test('empty list does not throw', () {
+      expect(() => PinBoundaryEnforcer.enforce([]), returnsNormally);
+    });
+
+    test('already-correct timings are unchanged', () {
+      final frags = [
+        _pinned(0, 0.0, 2.0),
+        _frag(1, 2.0, 5.0), // already starts exactly at pin end
+        _pinned(2, 5.0, 7.0),
+      ];
+
+      PinBoundaryEnforcer.enforce(frags);
+
+      expect(frags[1].realStart, closeTo(2.0, 0.001));
+      expect(frags[1].realEnd, closeTo(5.0, 0.001));
+    });
+  });
+
+  // ── Fragment pinning API tests ─────────────────────────────────────────────
+
+  group('Fragment.isPinned', () {
+    test('false by default', () {
+      expect(Fragment(index: 0, text: 'x').isPinned, isFalse);
+    });
+
+    test('true after setPinnedTiming', () {
+      final f = Fragment(index: 0, text: 'x');
+      f.setPinnedTiming(start: 1.0, end: 2.0);
+      expect(f.isPinned, isTrue);
+      expect(f.pinnedStart, closeTo(1.0, 0.001));
+      expect(f.pinnedEnd, closeTo(2.0, 0.001));
+    });
+
+    test('setPinnedTiming does not affect realStart/realEnd', () {
+      final f = Fragment(index: 0, text: 'x')
+        ..setRealTiming(start: 3.0, end: 4.0);
+      f.setPinnedTiming(start: 1.0, end: 2.0);
+      // realStart/realEnd are controlled by the processor, not setPinnedTiming
+      expect(f.realStart, closeTo(3.0, 0.001));
+      expect(f.realEnd, closeTo(4.0, 0.001));
+    });
+  });
+}

--- a/isochron_flutter/lib/services/alignment_service.dart
+++ b/isochron_flutter/lib/services/alignment_service.dart
@@ -10,6 +10,7 @@ class AlignmentService {
     required String ffmpegPath,
     required String espeakPath,
     String? dictPath,
+    String? pinsPath,
     bool hasIds = false,
     bool generateIds = false,
     String? generatedIdPrefix,
@@ -23,12 +24,18 @@ class AlignmentService {
       rulesJson = await File(dictPath).readAsString();
     }
 
+    String? pinsJson;
+    if (pinsPath != null && await File(pinsPath).exists()) {
+      pinsJson = await File(pinsPath).readAsString();
+    }
+
     try {
       await Isolate.spawn(_isolateEntry, {
         'sendPort': receivePort.sendPort,
         'textPath': textPath,
         'audioPath': audioPath,
         'rulesJson': rulesJson,
+        'pinsJson': pinsJson,
         'ffmpeg': ffmpegPath,
         'espeak': espeakPath,
         'hasIds': hasIds,
@@ -95,6 +102,19 @@ class AlignmentService {
       }
 
       // 1. Run Alignment on CLEAN text
+      Map<int, ({double start, double end})>? pinnedTimings;
+      if (args['pinsJson'] != null) {
+        final raw = jsonDecode(args['pinsJson']) as Map<String, dynamic>;
+        pinnedTimings = {
+          for (final entry in raw.entries)
+            if (int.tryParse(entry.key) != null)
+              int.parse(entry.key): (
+                start: (entry.value['start'] as num).toDouble(),
+                end: (entry.value['end'] as num).toDouble(),
+              ),
+        };
+      }
+
       final List<Fragment> rawFragments = await IsochronProcessor.process(
         text: cleanTextForEngine,
         audioPath: args['audioPath'],
@@ -102,6 +122,7 @@ class AlignmentService {
         ffmpegPath: args['ffmpeg'],
         espeakPath: args['espeak'],
         transliterationRules: rules,
+        pinnedTimings: pinnedTimings,
         onProgress: (s, p) =>
             sendPort.send({'type': 'progress', 'status': s, 'value': p}),
       );

--- a/isochron_flutter/lib/services/pins_service.dart
+++ b/isochron_flutter/lib/services/pins_service.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:isochron_cli/isochron_cli.dart';
+import 'package:path/path.dart' as p;
+
+/// Handles persistence of pinned fragment timings to a JSON sidecar file.
+///
+/// The sidecar sits alongside the alignment JSON:
+///   alignments/foo.json  →  alignments/foo-pins.json
+///
+/// Format:
+/// ```json
+/// {
+///   "0": { "start": 1.234, "end": 5.678 },
+///   "3": { "start": 12.0,  "end": 15.5  }
+/// }
+/// ```
+class PinsService {
+  /// Returns the sidecar pins path for a given alignment JSON path.
+  static String pinsPath(String alignmentJsonPath) {
+    final dir = p.dirname(alignmentJsonPath);
+    final stem = p.basenameWithoutExtension(alignmentJsonPath);
+    return p.join(dir, '$stem-pins.json');
+  }
+
+  /// Saves pinned fragments to the sidecar file alongside [alignmentJsonPath].
+  ///
+  /// If no fragments are pinned the file is deleted (or left absent), keeping
+  /// the project directory clean.
+  Future<void> save(String alignmentJsonPath, List<Fragment> fragments) async {
+    final path = pinsPath(alignmentJsonPath);
+    final pinned = fragments.where((f) => f.isPinned).toList();
+
+    if (pinned.isEmpty) {
+      final file = File(path);
+      if (await file.exists()) await file.delete();
+      return;
+    }
+
+    final map = <String, dynamic>{
+      for (final f in pinned)
+        '${f.index}': {
+          'start': double.parse(f.pinnedStart!.toStringAsFixed(3)),
+          'end': double.parse(f.pinnedEnd!.toStringAsFixed(3)),
+        },
+    };
+    await File(
+      path,
+    ).writeAsString(const JsonEncoder.withIndent('  ').convert(map));
+    debugPrint('[PIN] Saved pins to $path');
+  }
+
+  /// Reads the sidecar file and applies pinned timings to [fragments] in place.
+  ///
+  /// Silently no-ops if the file does not exist. Logs and swallows parse
+  /// errors so a corrupt sidecar never blocks opening a file.
+  Future<void> load(String alignmentJsonPath, List<Fragment> fragments) async {
+    final file = File(pinsPath(alignmentJsonPath));
+    if (!await file.exists()) return;
+
+    try {
+      final Map<String, dynamic> pinsMap = jsonDecode(
+        await file.readAsString(),
+      );
+      for (final entry in pinsMap.entries) {
+        final idx = int.tryParse(entry.key);
+        if (idx == null) continue;
+        final fragIdx = fragments.indexWhere((f) => f.index == idx);
+        if (fragIdx == -1) continue;
+        final v = entry.value as Map<String, dynamic>;
+        fragments[fragIdx].setPinnedTiming(
+          start: (v['start'] as num).toDouble(),
+          end: (v['end'] as num).toDouble(),
+        );
+      }
+      debugPrint('[PIN] Restored pins from ${file.path}');
+    } catch (e) {
+      debugPrint('[PIN] Failed to load pins: $e');
+    }
+  }
+}

--- a/isochron_flutter/lib/ui/home_manager.dart
+++ b/isochron_flutter/lib/ui/home_manager.dart
@@ -25,6 +25,20 @@ class HomeManager extends ValueNotifier<AppState> {
   final _settings = UserSettingsService();
   VoidCallback? onSaveCallback;
 
+  /// Snapshot of pin state as of the last explicit save (or file load).
+  /// Used by discardChanges() to revert both in-memory and on-disk pins
+  /// without losing pins that were already saved.
+  /// Null means no pins were saved.
+  Map<int, ({double start, double end})>? _lastSavedPins;
+
+  /// Builds a snapshot map from the pinned fragments in [frags].
+  static Map<int, ({double start, double end})> _buildPinsSnapshot(
+    List<Fragment> frags,
+  ) => {
+        for (final f in frags.where((f) => f.isPinned))
+          f.index: (start: f.pinnedStart!, end: f.pinnedEnd!),
+      };
+
   static const String _keyLastDir = 'last_picked_directory';
 
   HomeManager() : super(AppState(zoomLevel: UserSettingsService().lastZoom)) {
@@ -47,6 +61,10 @@ class HomeManager extends ValueNotifier<AppState> {
     String projectRoot, {
     String? dictPath,
   }) async {
+    // Reset pin snapshot for the new file — prevents stale state from a
+    // previous file carrying over if this file has no alignment JSON yet.
+    _lastSavedPins = null;
+
     // 1. Pause audio if it was playing from previous file
     if (value.isPlaying) {
       await _audioService.pause();
@@ -82,6 +100,9 @@ class HomeManager extends ValueNotifier<AppState> {
 
       // Restore any previously saved pin locks from sidecar file
       await _pinsService.load(absJsonPath, loadedFragments);
+
+      // Snapshot what was actually persisted so discard can revert here
+      _lastSavedPins = _buildPinsSnapshot(loadedFragments);
     }
 
     // 3.5. Load Dictionary if not already loaded into memory
@@ -147,6 +168,10 @@ class HomeManager extends ValueNotifier<AppState> {
       final jsonString = const JsonEncoder.withIndent('  ').convert(jsonList);
       await File(value.autoSavePath!).writeAsString(jsonString);
 
+      // Persist pins and update snapshot so discard now targets this save
+      await savePinsFile();
+      _lastSavedPins = _buildPinsSnapshot(value.fragments);
+
       value = value.copyWith(statusMessage: "Saved.", hasUnsavedChanges: false);
       onSaveCallback?.call();
     } catch (e) {
@@ -154,8 +179,26 @@ class HomeManager extends ValueNotifier<AppState> {
     }
   }
 
-  void discardChanges() {
-    value = value.copyWith(hasUnsavedChanges: false);
+  Future<void> discardChanges() async {
+    // Revert in-memory fragment pins to the last-saved snapshot
+    final frags = List<Fragment>.from(value.fragments);
+    final snapshot = _lastSavedPins ?? {};
+
+    for (final f in frags) {
+      final saved = snapshot[f.index];
+      if (saved != null) {
+        f.setPinnedTiming(start: saved.start, end: saved.end);
+      } else {
+        f.clearPinnedTiming();
+      }
+    }
+
+    // Rewrite (or delete) the sidecar to match the reverted state
+    if (value.autoSavePath != null) {
+      await _pinsService.save(value.autoSavePath!, frags);
+    }
+
+    value = value.copyWith(fragments: frags, hasUnsavedChanges: false);
   }
 
   Future<void> pickAudio() async {
@@ -479,7 +522,7 @@ class HomeManager extends ValueNotifier<AppState> {
       );
     }
 
-    value = value.copyWith(fragments: frags);
+    value = value.copyWith(fragments: frags, hasUnsavedChanges: true);
     await savePinsFile();
   }
 

--- a/isochron_flutter/lib/ui/home_manager.dart
+++ b/isochron_flutter/lib/ui/home_manager.dart
@@ -16,10 +16,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'models/app_state.dart';
 import '../services/alignment_service.dart';
 import '../services/audio_service.dart';
+import '../services/pins_service.dart';
 
 class HomeManager extends ValueNotifier<AppState> {
   final AudioService _audioService = AudioService();
   final AlignmentService _alignmentService = AlignmentService();
+  final PinsService _pinsService = PinsService();
   final _settings = UserSettingsService();
   VoidCallback? onSaveCallback;
 
@@ -77,6 +79,9 @@ class HomeManager extends ValueNotifier<AppState> {
                   ),
           )
           .toList();
+
+      // Restore any previously saved pin locks from sidecar file
+      await _pinsService.load(absJsonPath, loadedFragments);
     }
 
     // 3.5. Load Dictionary if not already loaded into memory
@@ -437,11 +442,24 @@ class HomeManager extends ValueNotifier<AppState> {
     hoveredFragmentIndex = idx;
   }
 
+  /// Path to the sidecar pins file: same directory as [autoSavePath] but with
+  /// a `-pins.json` suffix. Returns null when not in project mode.
+  String? get _pinsPath => value.autoSavePath == null
+      ? null
+      : PinsService.pinsPath(value.autoSavePath!);
+
+  /// Saves pinned fragments to the sidecar via [PinsService].
+  Future<void> savePinsFile() async {
+    final path = _pinsPath;
+    if (path == null) return;
+    await _pinsService.save(value.autoSavePath!, value.fragments);
+  }
+
   /// Toggles the pin lock on a fragment.
   /// When pinned, the fragment's current realStart/realEnd are locked in as
   /// ground-truth boundaries — drag handles are disabled and the alignment
   /// pipeline treats them as hard constraints on re-run.
-  void toggleFragmentPin(int index) {
+  void toggleFragmentPin(int index) async {
     final frags = List<Fragment>.from(value.fragments);
     if (index < 0 || index >= frags.length) return;
 
@@ -452,10 +470,12 @@ class HomeManager extends ValueNotifier<AppState> {
     } else {
       frag.setPinnedTiming(start: frag.realStart, end: frag.realEnd);
       debugPrint(
-          '[PIN] Fragment $index locked at ${frag.realStart.toStringAsFixed(3)}–${frag.realEnd.toStringAsFixed(3)}');
+        '[PIN] Fragment $index locked at ${frag.realStart.toStringAsFixed(3)}–${frag.realEnd.toStringAsFixed(3)}',
+      );
     }
 
     value = value.copyWith(fragments: frags);
+    await savePinsFile();
   }
 
   // --- Waveform Logic ---

--- a/isochron_flutter/lib/ui/home_manager.dart
+++ b/isochron_flutter/lib/ui/home_manager.dart
@@ -316,12 +316,17 @@ class HomeManager extends ValueNotifier<AppState> {
       // -----------------------
 
       // Run existing service with potentially new path
+      final activePinsPath = _pinsPath;
+      final passPins =
+          activePinsPath != null && await File(activePinsPath).exists();
+
       List<Fragment> fragments = await _alignmentService.runIsochron(
         textPath: actualTextPath,
         audioPath: value.audioPath!,
         dictPath: value.dictPath,
         ffmpegPath: ffmpeg,
         espeakPath: espeak,
+        pinsPath: passPins ? activePinsPath : null,
         onProgress: (status, prog) {
           value = value.copyWith(statusMessage: status, progress: prog);
         },

--- a/isochron_flutter/lib/ui/home_manager.dart
+++ b/isochron_flutter/lib/ui/home_manager.dart
@@ -428,6 +428,36 @@ class HomeManager extends ValueNotifier<AppState> {
     }
   }
 
+  /// Index of the fragment the mouse is currently hovering over in the
+  /// waveform view. Updated by WaveformView on every mouse-move; used by the
+  /// `L` keyboard shortcut so it doesn't require a prior double-click.
+  int? hoveredFragmentIndex;
+
+  void setHoveredFragmentIndex(int? idx) {
+    hoveredFragmentIndex = idx;
+  }
+
+  /// Toggles the pin lock on a fragment.
+  /// When pinned, the fragment's current realStart/realEnd are locked in as
+  /// ground-truth boundaries — drag handles are disabled and the alignment
+  /// pipeline treats them as hard constraints on re-run.
+  void toggleFragmentPin(int index) {
+    final frags = List<Fragment>.from(value.fragments);
+    if (index < 0 || index >= frags.length) return;
+
+    final frag = frags[index];
+    if (frag.isPinned) {
+      frag.clearPinnedTiming();
+      debugPrint('[PIN] Fragment $index unlocked');
+    } else {
+      frag.setPinnedTiming(start: frag.realStart, end: frag.realEnd);
+      debugPrint(
+          '[PIN] Fragment $index locked at ${frag.realStart.toStringAsFixed(3)}–${frag.realEnd.toStringAsFixed(3)}');
+    }
+
+    value = value.copyWith(fragments: frags);
+  }
+
   // --- Waveform Logic ---
 
   Future<void> _generateWaveform(String audioPath) async {

--- a/isochron_flutter/lib/ui/home_screen.dart
+++ b/isochron_flutter/lib/ui/home_screen.dart
@@ -98,7 +98,7 @@ class _MainScreenState extends State<MainScreen> {
       await _controller.saveProject();
       return true; // Proceed after saving
     } else if (result == 'discard') {
-      _controller.discardChanges();
+      await _controller.discardChanges();
       return true; // Proceed and lose changes
     }
 

--- a/isochron_flutter/lib/ui/home_screen.dart
+++ b/isochron_flutter/lib/ui/home_screen.dart
@@ -190,6 +190,13 @@ class _MainScreenState extends State<MainScreen> {
             _goToNextFile,
         const SingleActivator(LogicalKeyboardKey.keyN, control: true):
             _goToNextFile,
+
+        // L: Lock / unlock the hovered (or focused) fragment's timing pin
+        const SingleActivator(LogicalKeyboardKey.keyL): () {
+          final idx = _controller.hoveredFragmentIndex ??
+              _controller.value.focusedFragmentIndex;
+          if (idx != null) _controller.toggleFragmentPin(idx);
+        },
       },
       child: Focus(
         autofocus: true,

--- a/isochron_flutter/lib/ui/waveform/fragment_list.dart
+++ b/isochron_flutter/lib/ui/waveform/fragment_list.dart
@@ -113,10 +113,14 @@ class _FragmentListState extends State<FragmentList> {
                 children: [
                   CircleAvatar(
                     radius: 10,
-                    backgroundColor: isActive
+                    backgroundColor: f.isPinned
+                        ? const Color(0xFFFFC107)
+                        : isActive
                         ? colorScheme.primary
                         : colorScheme.surfaceContainerHighest,
-                    foregroundColor: isActive
+                    foregroundColor: f.isPinned
+                        ? Colors.black
+                        : isActive
                         ? colorScheme.onPrimary
                         : colorScheme.onSurfaceVariant,
                     child: Text(
@@ -127,6 +131,10 @@ class _FragmentListState extends State<FragmentList> {
                       ),
                     ),
                   ),
+                  if (f.isPinned) ...[
+                    const SizedBox(height: 4),
+                    const Icon(Icons.lock, size: 12, color: Color(0xFFFFC107)),
+                  ],
                 ],
               ),
               title: Row(

--- a/isochron_flutter/lib/ui/waveform/waveform_painter.dart
+++ b/isochron_flutter/lib/ui/waveform/waveform_painter.dart
@@ -65,16 +65,22 @@ class IsochronWaveformPainter extends CustomPainter {
     }
   }
 
-  void _drawFragments(Canvas canvas, Size size) {
-    final paintLine = Paint()
-      ..color = accentColor
-      ..strokeWidth = 2.0;
+  // Amber used for pinned fragment boundaries — semantic, not theme-dependent.
+  static const Color _pinnedColor = Color(0xFFFFC107); // Colors.amber
 
-    // Fill background for the verse
-    final paintFill = Paint()..color = accentColor.withValues(alpha: 0.15);
+  void _drawFragments(Canvas canvas, Size size) {
     final textPainter = TextPainter(textDirection: TextDirection.ltr);
 
     for (final frag in fragments) {
+      final bool pinned = frag.isPinned;
+      final Color lineColor = pinned ? _pinnedColor : accentColor;
+
+      final paintLine = Paint()
+        ..color = lineColor
+        ..strokeWidth = pinned ? 2.5 : 2.0;
+
+      final paintFill = Paint()..color = lineColor.withValues(alpha: 0.15);
+
       // Map time -> pixels using contentWidth
       final xStart = (frag.realStart / totalSeconds) * size.width;
       final xEnd = (frag.realEnd / totalSeconds) * size.width;
@@ -87,11 +93,13 @@ class IsochronWaveformPainter extends CustomPainter {
       );
       canvas.drawLine(Offset(xEnd, 0), Offset(xEnd, size.height), paintLine);
 
+      // Pin indicator drawn as a widget overlay in WaveformView — nothing to paint here.
+
       if (xEnd - xStart > 25) {
         textPainter.text = TextSpan(
           text: "${frag.index}",
           style: TextStyle(
-            color: accentColor,
+            color: lineColor,
             fontWeight: FontWeight.bold,
             fontSize: 10,
           ),

--- a/isochron_flutter/lib/ui/waveform/waveform_view.dart
+++ b/isochron_flutter/lib/ui/waveform/waveform_view.dart
@@ -133,8 +133,13 @@ class _WaveformViewState extends State<WaveformView> {
                   _handleHover(event.localPosition.dx, contentWidth, totalSec),
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
-                onTapUp: (d) =>
-                    _handleSeek(d.localPosition.dx, contentWidth, totalSec),
+                onTapDown: (d) =>
+                    _handleTap(d.localPosition.dx, contentWidth, totalSec),
+                onDoubleTapDown: (d) => _handleDoubleTap(
+                  d.localPosition.dx,
+                  contentWidth,
+                  totalSec,
+                ),
                 onHorizontalDragStart: (d) => _handleDragStart(
                   d.localPosition.dx,
                   contentWidth,
@@ -149,24 +154,49 @@ class _WaveformViewState extends State<WaveformView> {
                   _dragIndex = null;
                   _cursor = SystemMouseCursors.basic;
                 }),
-                child: CustomPaint(
-                  size: Size(fullPainterWidth, constraints.maxHeight),
-                  painter: IsochronWaveformPainter(
-                    waveform: wf,
-                    fragments: widget.state.fragments,
-                    playbackPosSeconds:
-                        widget.state.currentPlaybackPosition.inMilliseconds /
-                        1000.0,
-                    totalSeconds: totalSec,
-                    zoomLevel: widget.state.zoomLevel,
-                    accentColor: Theme.of(context).colorScheme.primary,
-                    waveColor: Theme.of(
-                      context,
-                    ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-                    playheadColor: Theme.of(context).colorScheme.error,
-                    contentWidth: contentWidth,
-                    padding: _hPadding,
-                  ),
+                child: Stack(
+                  children: [
+                    CustomPaint(
+                      size: Size(fullPainterWidth, constraints.maxHeight),
+                      painter: IsochronWaveformPainter(
+                        waveform: wf,
+                        fragments: widget.state.fragments,
+                        playbackPosSeconds:
+                            widget
+                                .state
+                                .currentPlaybackPosition
+                                .inMilliseconds /
+                            1000.0,
+                        totalSeconds: totalSec,
+                        zoomLevel: widget.state.zoomLevel,
+                        accentColor: Theme.of(context).colorScheme.primary,
+                        waveColor: Theme.of(
+                          context,
+                        ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                        playheadColor: Theme.of(context).colorScheme.error,
+                        contentWidth: contentWidth,
+                        padding: _hPadding,
+                      ),
+                    ),
+                    // Lock icon overlays for pinned fragments
+                    for (final f in widget.state.fragments)
+                      if (f.isPinned)
+                        Positioned(
+                          left:
+                              (f.realStart + f.realEnd) /
+                                  2 /
+                                  totalSec *
+                                  contentWidth +
+                              _hPadding -
+                              8,
+                          top: 4,
+                          child: const Icon(
+                            Icons.lock,
+                            size: 16,
+                            color: Color(0xFFFFC107), // amber
+                          ),
+                        ),
+                  ],
                 ),
               ),
             ),
@@ -188,17 +218,27 @@ class _WaveformViewState extends State<WaveformView> {
     // 2. Convert the hover X pixel to Audio Time
     final hoverTime = _pxToSeconds(x, contentWidth, totalSec);
 
-    // 3. Calculate the time difference equivalent to our pixel threshold.
+    // 3. Track which fragment the cursor is currently inside (for L key)
+    int? hoveredIdx;
+    for (final f in widget.state.fragments) {
+      if (hoverTime >= f.realStart && hoverTime <= f.realEnd) {
+        hoveredIdx = f.index;
+        break;
+      }
+    }
+    widget.controller.setHoveredFragmentIndex(hoveredIdx);
+
+    // 4. Calculate the time difference equivalent to our pixel threshold.
     // Logic: (Pixels / TotalWidth) * TotalSeconds
     final double thresholdSeconds =
         (_hoverThresholdPx / contentWidth) * totalSec;
 
     bool isNearBoundary = false;
 
-    // 4. Check all fragments
-    // (Optimization note: For huge lists, we could optimize this to only check
-    // fragments currently in the viewport, but for <5000 lines this is fast enough)
-    for (var f in widget.state.fragments) {
+    // 5. Check non-pinned fragments only — pinned handles cannot be dragged
+    // so we suppress the resize cursor near them to avoid confusion.
+    for (final f in widget.state.fragments) {
+      if (f.isPinned) continue;
       if ((f.realStart - hoverTime).abs() < thresholdSeconds ||
           (f.realEnd - hoverTime).abs() < thresholdSeconds) {
         isNearBoundary = true;
@@ -206,7 +246,7 @@ class _WaveformViewState extends State<WaveformView> {
       }
     }
 
-    // 5. Update state only if changed to avoid unnecessary rebuilds
+    // 6. Update state only if changed to avoid unnecessary rebuilds
     final newCursor = isNearBoundary
         ? SystemMouseCursors.resizeLeftRight
         : SystemMouseCursors.basic;
@@ -227,6 +267,22 @@ class _WaveformViewState extends State<WaveformView> {
     widget.controller.seekTo(Duration(milliseconds: ms));
   }
 
+  void _handleTap(double x, double contentWidth, double totalSec) {
+    _handleSeek(x, contentWidth, totalSec);
+  }
+
+  // Double-tap anywhere inside a fragment region toggles its pin lock.
+  void _handleDoubleTap(double x, double contentWidth, double totalSec) {
+    for (final f in widget.state.fragments) {
+      final fragStartPx = (f.realStart / totalSec) * contentWidth + _hPadding;
+      final fragEndPx = (f.realEnd / totalSec) * contentWidth + _hPadding;
+      if (x >= fragStartPx && x <= fragEndPx) {
+        widget.controller.toggleFragmentPin(f.index);
+        return;
+      }
+    }
+  }
+
   void _handleDragStart(double x, double contentWidth, double totalSec) {
     final time = _pxToSeconds(x, contentWidth, totalSec);
 
@@ -235,15 +291,32 @@ class _WaveformViewState extends State<WaveformView> {
     // Threshold in seconds (e.g. 15 pixels worth of time)
     final thresholdSec = 15.0 / pixelsPerSecond;
 
+    // Collect all positions that are locked by a pin — no drag handle may
+    // land within threshold of these, even if it belongs to a neighbour.
+    final pinnedPositions = <double>{};
+    for (final f in widget.state.fragments) {
+      if (f.isPinned) {
+        pinnedPositions.add(f.realStart);
+        pinnedPositions.add(f.realEnd);
+      }
+    }
+
+    bool isNearPinned(double t) =>
+        pinnedPositions.any((p) => (p - t).abs() < thresholdSec);
+
     for (var f in widget.state.fragments) {
-      if ((f.realStart - time).abs() < thresholdSec) {
+      // Pinned fragments: both handles are fully locked
+      if (f.isPinned) continue;
+
+      if ((f.realStart - time).abs() < thresholdSec &&
+          !isNearPinned(f.realStart)) {
         setState(() {
           _dragIndex = f.index;
           _dragStart = true;
         });
         return;
       }
-      if ((f.realEnd - time).abs() < thresholdSec) {
+      if ((f.realEnd - time).abs() < thresholdSec && !isNearPinned(f.realEnd)) {
         setState(() {
           _dragIndex = f.index;
           _dragStart = false;

--- a/isochron_flutter/macos/Podfile.lock
+++ b/isochron_flutter/macos/Podfile.lock
@@ -37,12 +37,12 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
 
 SPEC CHECKSUMS:
-  audio_session: eaca2512cf2b39212d724f35d11f46180ad3a33e
-  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
+  audio_session: 728ae3823d914f809c485d390274861a24b0904e
+  file_picker: e716a70a9fe5fd9e09ebc922d7541464289443af
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
-  just_waveform: be2cb6dec86096cb972bf8b73c893fe16bf1cff4
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  just_audio: a42c63806f16995daf5b219ae1d679deb76e6a79
+  just_waveform: dbade622f9d7a0c8de7cc8e43c424617c6bc7113
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/isochron_flutter/test/services/pins_service_test.dart
+++ b/isochron_flutter/test/services/pins_service_test.dart
@@ -1,0 +1,187 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isochron_cli/isochron_cli.dart';
+import 'package:isochron_flutter/services/pins_service.dart';
+import 'package:path/path.dart' as p;
+
+/// Builds a Fragment with real timing set.
+Fragment makeFragment(int index, double start, double end) {
+  return Fragment(index: index, text: 'text $index')
+    ..setRealTiming(start: start, end: end);
+}
+
+void main() {
+  late Directory tempDir;
+  late String alignmentPath;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('pins_service_test_');
+    alignmentPath = p.join(tempDir.path, 'foo.json');
+    File(alignmentPath).writeAsStringSync('[]');
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  // ---------------------------------------------------------------------------
+  group('PinsService.pinsPath', () {
+    test('derives correct sidecar path', () {
+      final result = PinsService.pinsPath('/project/alignments/foo.json');
+      expect(result, '/project/alignments/foo-pins.json');
+    });
+
+    test('works with nested paths', () {
+      expect(PinsService.pinsPath('/a/b/c/bar.json'), '/a/b/c/bar-pins.json');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('PinsService.save', () {
+    test(
+      'creates pins file with correct JSON when a fragment is pinned',
+      () async {
+        final service = PinsService();
+        final frags = [makeFragment(0, 1.0, 3.0), makeFragment(1, 3.0, 7.5)];
+        frags[0].setPinnedTiming(start: 1.0, end: 3.0);
+
+        await service.save(alignmentPath, frags);
+
+        final pinsFile = File(PinsService.pinsPath(alignmentPath));
+        expect(await pinsFile.exists(), isTrue);
+
+        final map = jsonDecode(await pinsFile.readAsString()) as Map;
+        expect(map.keys.toList(), ['0']);
+        expect((map['0']['start'] as num).toDouble(), 1.0);
+        expect((map['0']['end'] as num).toDouble(), 3.0);
+      },
+    );
+
+    test('writes all pinned fragments', () async {
+      final service = PinsService();
+      final frags = [
+        makeFragment(0, 0.0, 2.0),
+        makeFragment(1, 2.0, 5.0),
+        makeFragment(2, 5.0, 9.0),
+      ];
+      frags[0].setPinnedTiming(start: 0.0, end: 2.0);
+      frags[2].setPinnedTiming(start: 5.0, end: 9.0);
+
+      await service.save(alignmentPath, frags);
+
+      final map =
+          jsonDecode(
+                await File(PinsService.pinsPath(alignmentPath)).readAsString(),
+              )
+              as Map;
+      expect(map.keys.toSet(), {'0', '2'});
+    });
+
+    test('deletes existing pins file when no fragments are pinned', () async {
+      final service = PinsService();
+      File(PinsService.pinsPath(alignmentPath)).writeAsStringSync('{}');
+
+      await service.save(alignmentPath, [makeFragment(0, 0.0, 2.0)]);
+
+      expect(await File(PinsService.pinsPath(alignmentPath)).exists(), isFalse);
+    });
+
+    test('does not throw when no pins and no sidecar exists', () async {
+      await expectLater(
+        PinsService().save(alignmentPath, [makeFragment(0, 0.0, 2.0)]),
+        completes,
+      );
+      expect(await File(PinsService.pinsPath(alignmentPath)).exists(), isFalse);
+    });
+
+    test('rounds timing values to 3 decimal places', () async {
+      final frags = [makeFragment(0, 0.0, 9.0)];
+      frags[0].setPinnedTiming(start: 1.23456789, end: 4.56789);
+
+      await PinsService().save(alignmentPath, frags);
+
+      final map =
+          jsonDecode(
+                await File(PinsService.pinsPath(alignmentPath)).readAsString(),
+              )
+              as Map;
+      expect(map['0']['start'], 1.235);
+      expect(map['0']['end'], 4.568);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('PinsService.load', () {
+    test('applies pinned timings to matching fragments', () async {
+      File(PinsService.pinsPath(alignmentPath)).writeAsStringSync(
+        jsonEncode({
+          '1': {'start': 3.0, 'end': 7.5},
+        }),
+      );
+
+      final frags = [makeFragment(0, 0.0, 3.0), makeFragment(1, 3.0, 7.5)];
+      await PinsService().load(alignmentPath, frags);
+
+      expect(frags[0].isPinned, isFalse);
+      expect(frags[1].isPinned, isTrue);
+      expect(frags[1].pinnedStart, 3.0);
+      expect(frags[1].pinnedEnd, 7.5);
+    });
+
+    test('is a no-op when sidecar does not exist', () async {
+      final frags = [makeFragment(0, 0.0, 2.0)];
+      await expectLater(PinsService().load(alignmentPath, frags), completes);
+      expect(frags[0].isPinned, isFalse);
+    });
+
+    test('handles corrupt JSON without throwing', () async {
+      File(PinsService.pinsPath(alignmentPath)).writeAsStringSync('NOT JSON');
+
+      final frags = [makeFragment(0, 0.0, 2.0)];
+      await expectLater(PinsService().load(alignmentPath, frags), completes);
+      expect(frags[0].isPinned, isFalse);
+    });
+
+    test('skips unknown fragment indices gracefully', () async {
+      File(PinsService.pinsPath(alignmentPath)).writeAsStringSync(
+        jsonEncode({
+          '99': {'start': 1.0, 'end': 2.0},
+        }),
+      );
+
+      final frags = [makeFragment(0, 0.0, 2.0)];
+      await expectLater(PinsService().load(alignmentPath, frags), completes);
+      expect(frags[0].isPinned, isFalse);
+    });
+
+    test('round-trips: save then load restores all pins', () async {
+      final service = PinsService();
+      final orig = [
+        makeFragment(0, 1.0, 3.5),
+        makeFragment(1, 3.5, 8.0),
+        makeFragment(2, 8.0, 12.0),
+      ];
+      orig[0].setPinnedTiming(start: 1.0, end: 3.5);
+      orig[2].setPinnedTiming(start: 8.0, end: 12.0);
+      await service.save(alignmentPath, orig);
+
+      // Fresh unpinned list
+      final restored = [
+        makeFragment(0, 1.0, 3.5),
+        makeFragment(1, 3.5, 8.0),
+        makeFragment(2, 8.0, 12.0),
+      ];
+      await service.load(alignmentPath, restored);
+
+      expect(restored[0].isPinned, isTrue);
+      expect(restored[0].pinnedStart, 1.0);
+      expect(restored[0].pinnedEnd, 3.5);
+      expect(restored[1].isPinned, isFalse);
+      expect(restored[2].isPinned, isTrue);
+      expect(restored[2].pinnedStart, 8.0);
+      expect(restored[2].pinnedEnd, 12.0);
+    });
+  });
+}


### PR DESCRIPTION
I added a feature that allows the user to lock the timing positions. This lets them realign the audio without losing the already approved timing. You can double click the fragment to lock, or press L when hovering over it. Do that again to unlock it. I also added a `--pins` argument to the CLI to send locked pins to the processing of an audio file. This takes a JSON file formatted like this:

```json
{
  "0": { "start": 0.0,  "end": 1.4  },
  "7": { "start": 12.3, "end": 15.2 }
}
```

Lastly, I added an AI generated technical document outlining the CLI process of analyzing an audio file. This is to help new developers onboard easier on the project.