### PR TITLE
feat: 🔒 Add bulk lock for fragments through focus

### DIFF
--- a/isochron_flutter/lib/ui/home_manager.dart
+++ b/isochron_flutter/lib/ui/home_manager.dart
@@ -546,6 +546,24 @@ class HomeManager extends ValueNotifier<AppState> {
     await savePinsFile();
   }
 
+  /// Locks all fragments up to and including the given index.
+  void lockFragmentsUntil(int index) async {
+    final frags = List<Fragment>.from(value.fragments);
+    if (index < 0 || index >= frags.length) return;
+
+    for (int i = 0; i <= index; i++) {
+      final frag = frags[i];
+
+      frag.setPinnedTiming(start: frag.realStart, end: frag.realEnd);
+      debugPrint(
+        '[PIN] Fragment $index locked at ${frag.realStart.toStringAsFixed(3)}–${frag.realEnd.toStringAsFixed(3)}',
+      );
+    }
+
+    value = value.copyWith(fragments: frags, hasUnsavedChanges: true);
+    await savePinsFile();
+  }
+
   // --- Waveform Logic ---
 
   Future<void> _generateWaveform(String audioPath) async {

--- a/isochron_flutter/lib/ui/home_screen.dart
+++ b/isochron_flutter/lib/ui/home_screen.dart
@@ -196,6 +196,14 @@ class _MainScreenState extends State<MainScreen> {
           final idx =
               _controller.hoveredFragmentIndex ??
               _controller.value.focusedFragmentIndex;
+          if (idx != null) _controller.lockFragmentsUntil(idx);
+        },
+
+        // L: Lock / unlock the hovered (or focused) fragment's timing pin
+        const SingleActivator(LogicalKeyboardKey.keyL, shift: true): () {
+          final idx =
+              _controller.hoveredFragmentIndex ??
+              _controller.value.focusedFragmentIndex;
           if (idx != null) _controller.toggleFragmentPin(idx);
         },
 


### PR DESCRIPTION
`L` pins real timing for every fragment from the first through the hovered or focused index via `HomeManager.lockFragmentsUntil`, then marks the project dirty and saves pins.

`Shift+L` keeps the previous single-fragment toggle (`toggleFragmentPin`) so you can still lock or unlock any fragment, one at a time.