### PR TITLE
feat: 🪄 Add timing-file export across Flutter UI and CLI with shared export core

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The core engine is 100% Dart, based on open-domain DSP theory, and completely fr
 * **Pro Timeline Gestures:** Navigate the timeline exactly like Logic Pro or Final Cut. Two-finger swipe to pan seamlessly, and two-finger vertical swipe (or pinch) for buttery-smooth exponential zooming anchored right to your mouse pointer.
 * **Global Transliteration:** Provide a JSON map of non-Latin to Latin characters to instantly apply transliteration rules across your entire project.
 * **Headless Batch Processor:** Queue up dozens of alignments, hit "Run All", and export everything into a unified CSV database when finished.
-* **Phrase Timing Export:** Export phrase timing text files per alignment from batch tiles or the editor toolbar when the pair is finalized.
+* **Phrase Timing Export:** Export phrase timing text files per alignment from alignment-list tiles or the editor toolbar when the pair is finalized.
 
 ---
 
@@ -34,7 +34,7 @@ flutter run -d macos
 Isochron uses a professional **Asset Pool** architecture. You don't have to manually match files before importing them.
 
 1. **Create a Project:** On the welcome screen, click "Create New Project". Type a name, pick a location (like your Desktop), and Isochron will instantly build the directory structure for you.
-2. **Import Assets:** Use the left sidebar to navigate to the **Audio Pool** and **Text Pool**. Click the `+` icon in the top toolbar to import your `.mp3`/`.wav` and `.txt`/`.phrases` files.
+2. **Import Assets:** Use the left sidebar to navigate to the **Audio Pool** and **Text Pool**. Click the `+` icon in the top toolbar to import your `.mp3`/`.wav` and `.txt`/`.phrase` files.
 3. **Auto-Pair:** Navigate to **Alignments** in the sidebar. Click the **Auto-Pair Unlinked** button (the layered wand icon) to instantly create linked pairs from your imported files.
 4. **Align:** Select the **Batch Processor** tab and click "Run All Pending" to process them automatically, OR double-click a single pair to open the manual **Studio Editor**.
 
@@ -99,6 +99,14 @@ dart run bin/isochron_cli.dart \
   --output result.json
 ```
 
+**Timing Export (same run, same output flag):**
+```bash
+dart run bin/isochron_cli.dart \
+  --text TH-01-GEN-01.txt \
+  --audio recording.mp3 \
+  --output result.txt
+```
+
 **Advanced Usage:**
 ```bash
 dart run bin/isochron_cli.dart \
@@ -110,6 +118,8 @@ dart run bin/isochron_cli.dart \
 ```
 
 ### CLI Options Explained
+* **`--output`:** Single destination path for both JSON and timing exports.
+* **`--format` (`json` or `timing`):** Optional explicit output selector. If omitted, format is inferred from `--output` extension (`.json` => JSON, `.txt` => timing), then defaults to JSON.
 * **`--snap-mode` (`onset` or `gap`):** Boundary refinement mode. `onset` snaps the fragment toward the speech start. `gap` snaps boundaries toward the center of detected silences.
 * **`--snap-offset`:** Milliseconds subtracted from each onset-snapped phrase start (e.g. `250`).
 * **`--pins` (Pinned Timings):** Pass a JSON file of known-correct fragment timings (e.g. `{"0": {"start": 0.0, "end": 1.4}}`). The engine will lock these in and only perform DTW in the spaces *between* your pins.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The core engine is 100% Dart, based on open-domain DSP theory, and completely fr
 * **Pro Timeline Gestures:** Navigate the timeline exactly like Logic Pro or Final Cut. Two-finger swipe to pan seamlessly, and two-finger vertical swipe (or pinch) for buttery-smooth exponential zooming anchored right to your mouse pointer.
 * **Global Transliteration:** Provide a JSON map of non-Latin to Latin characters to instantly apply transliteration rules across your entire project.
 * **Headless Batch Processor:** Queue up dozens of alignments, hit "Run All", and export everything into a unified CSV database when finished.
+* **Phrase Timing Export:** Export phrase timing text files per alignment from batch tiles or the editor toolbar when the pair is finalized.
 
 ---
 
@@ -33,9 +34,20 @@ flutter run -d macos
 Isochron uses a professional **Asset Pool** architecture. You don't have to manually match files before importing them.
 
 1. **Create a Project:** On the welcome screen, click "Create New Project". Type a name, pick a location (like your Desktop), and Isochron will instantly build the directory structure for you.
-2. **Import Assets:** Use the left sidebar to navigate to the **Audio Pool** and **Text Pool**. Click the `+` icon in the top toolbar to import your `.mp3`/`.wav` and `.txt` files.
+2. **Import Assets:** Use the left sidebar to navigate to the **Audio Pool** and **Text Pool**. Click the `+` icon in the top toolbar to import your `.mp3`/`.wav` and `.txt`/`.phrases` files.
 3. **Auto-Pair:** Navigate to **Alignments** in the sidebar. Click the **Auto-Pair Unlinked** button (the layered wand icon) to instantly create linked pairs from your imported files.
 4. **Align:** Select the **Batch Processor** tab and click "Run All Pending" to process them automatically, OR double-click a single pair to open the manual **Studio Editor**.
+
+### Export Notes
+
+* **Combined CSV Export:** Available from the Batch Processor toolbar. It includes only alignments with status `done` or `reviewed`.
+* **Phrase Timing Export:** Available from alignment-list tiles and in-editor toolbar for a specific alignment.
+  * Enabled only when status is `done` or `reviewed`.
+  * Disabled-state tooltip explains when status is not eligible.
+  * Suggested output name is derived from input text filename as:
+    `<original-base><separator>timing.txt`.
+    * Separator detection supports `-`, `_`, and spaces.
+    * If source uses spaces, output suffix separator is normalized to `-`.
 
 ---
 

--- a/isochron_cli/bin/isochron_cli.dart
+++ b/isochron_cli/bin/isochron_cli.dart
@@ -5,6 +5,7 @@ import 'package:isochron_cli/src/core/isochron_processor.dart';
 import 'package:isochron_cli/src/core/drivers.dart';
 import 'package:isochron_cli/src/platform/mac_drivers.dart';
 import 'package:isochron_cli/src/core/boundary_strategy.dart';
+import 'package:isochron_cli/src/core/timing_export.dart';
 
 void main(List<String> arguments) async {
   final parser = ArgParser()
@@ -12,8 +13,11 @@ void main(List<String> arguments) async {
     ..addOption('audio', abbr: 'a', help: 'Path to the input audio file')
     ..addOption('output',
         abbr: 'o',
-        help: 'Path to save the alignment JSON',
-        defaultsTo: 'alignment.json')
+        help: 'Path to save output (JSON or timing text). '
+            'If omitted, derived from --text filename and resolved format.')
+    ..addOption('format',
+        allowed: ['json', 'timing'],
+        help: 'Output format. If omitted, inferred from --output extension.')
     ..addOption('dict',
         help: 'Path to a JSON file containing transliteration rules')
     ..addOption('pins',
@@ -50,7 +54,9 @@ void main(List<String> arguments) async {
     final audioPath = results['audio'];
     final dictPath = results['dict'];
     final pinsPath = results['pins'];
-    final outputJsonPath = results['output'];
+    final outputPath = results['output'] as String?;
+    final requestedFormat = results['format'] as String?;
+
     final snapModeRaw = results['snap-mode'] as String? ?? 'onset';
     final snapOffsetRaw = results['snap-offset'] as String?;
     final verbose = results['verbose'] as bool;
@@ -78,6 +84,16 @@ void main(List<String> arguments) async {
       print(parser.usage);
       exit(1);
     }
+
+    // Centralized in shared core: format precedence, derived defaults from
+    // source text when output is omitted, and extension normalization.
+    final effectiveOutput = TimingExport.resolveEffectiveOutput(
+      explicitOutputPath: outputPath,
+      requestedFormat: requestedFormat,
+      sourceTextPath: textPath,
+    );
+    final effectiveFormat = effectiveOutput.format;
+    final effectiveOutputPath = effectiveOutput.outputPath;
 
     // --- Load Dictionary ---
     if (dictPath != null) {
@@ -186,20 +202,29 @@ void main(List<String> arguments) async {
       }
 
       // --- Output Generation ---
-      final jsonOutput = fragments
-          .map((f) => {
-                'index': f.index,
-                if (f.id != null) 'id': f.id,
-                'text': f.text,
-                'start': double.parse(f.realStart.toStringAsFixed(3)),
-                'end': double.parse(f.realEnd.toStringAsFixed(3)),
-              })
-          .toList();
+      if (effectiveFormat == CliOutputFormat.json) {
+        // Preserve existing JSON schema for downstream compatibility.
+        final jsonOutput = fragments
+            .map((f) => {
+                  'index': f.index,
+                  if (f.id != null) 'id': f.id,
+                  'text': f.text,
+                  'start': double.parse(f.realStart.toStringAsFixed(3)),
+                  'end': double.parse(f.realEnd.toStringAsFixed(3)),
+                })
+            .toList();
 
-      final jsonFile = File(outputJsonPath);
-      await jsonFile.writeAsString(jsonEncode(jsonOutput));
+        final jsonFile = File(effectiveOutputPath);
+        await jsonFile.writeAsString(jsonEncode(jsonOutput));
+      } else {
+        // Timing export reuses shared core so CLI + Flutter stay identical.
+        final metadata = TimingExport.parseMetadataFromSourceFilename(textPath);
+        final payload = TimingExport.generateTimingPayload(fragments, metadata);
+        final textFile = File(effectiveOutputPath);
+        await textFile.writeAsString(payload);
+      }
 
-      print('Success! Saved to: $outputJsonPath');
+      print('Success! Saved to: $effectiveOutputPath');
     } catch (e, stack) {
       stderr.writeln('Critical Error: $e');
       if (verbose) stderr.writeln(stack);

--- a/isochron_cli/lib/isochron_cli.dart
+++ b/isochron_cli/lib/isochron_cli.dart
@@ -10,6 +10,7 @@ export 'src/core/isochron_processor.dart';
 export 'src/core/transliterator.dart';
 export 'src/core/pin_boundary_enforcer.dart';
 export 'src/core/boundary_strategy.dart';
+export 'src/core/timing_export.dart';
 
 // Drivers
 export 'src/core/drivers.dart';

--- a/isochron_cli/lib/src/core/timing_export.dart
+++ b/isochron_cli/lib/src/core/timing_export.dart
@@ -1,0 +1,197 @@
+import 'package:path/path.dart' as p;
+
+import 'fragment.dart';
+
+enum CliOutputFormat { json, timing }
+
+class TimingExportMetadata {
+  final String languageCode;
+  final String bookId;
+  final String bookCode;
+  final String chapterId;
+
+  const TimingExportMetadata({
+    required this.languageCode,
+    required this.bookId,
+    required this.bookCode,
+    required this.chapterId,
+  });
+
+  static const fallback = TimingExportMetadata(
+    languageCode: 'XX',
+    bookId: '00',
+    bookCode: 'BOOK',
+    chapterId: '1',
+  );
+}
+
+class TimingExport {
+  /// Resolves the final output contract in one place for all callers:
+  /// - picks effective format (explicit `--format` > extension inference),
+  /// - derives a default filename when no explicit output is provided,
+  /// - normalizes extension so filename always matches actual content type.
+  static ({CliOutputFormat format, String outputPath}) resolveEffectiveOutput({
+    required String? explicitOutputPath,
+    required String? requestedFormat,
+    required String? sourceTextPath,
+  }) {
+    final format = resolveOutputFormat(
+      outputPath: explicitOutputPath ?? '',
+      requestedFormat: requestedFormat,
+    );
+    final rawPath = explicitOutputPath ??
+        (format == CliOutputFormat.timing
+            ? defaultTimingFilenameFromSourcePath(sourceTextPath)
+            : defaultJsonFilenameFromSourcePath(sourceTextPath));
+    final normalizedPath =
+        normalizeOutputPathForFormat(outputPath: rawPath, format: format);
+    return (format: format, outputPath: normalizedPath);
+  }
+
+  /// Parses `LANG-BOOKID-BOOK-CHAPTER[_SUFFIX]` style source names.
+  ///
+  /// Parsing is separator-tolerant (`-`, `_`, whitespace) and suffix-tolerant
+  /// by using the rightmost numeric token as chapter id.
+  static TimingExportMetadata parseMetadataFromSourceFilename(
+    String? sourcePath,
+  ) {
+    if (sourcePath == null || sourcePath.trim().isEmpty) {
+      return TimingExportMetadata.fallback;
+    }
+
+    final base = p.basenameWithoutExtension(sourcePath);
+    final separator = _detectFilenameSeparator(base);
+    final parts = _splitBySeparator(base, separator);
+    if (parts.length < 4) return TimingExportMetadata.fallback;
+
+    final languageCode = parts[0].trim();
+    final bookId = parts[1].trim();
+    final chapterIdx = _findChapterTokenIndex(parts);
+    if (chapterIdx <= 2) return TimingExportMetadata.fallback;
+
+    final chapterId = parts[chapterIdx].trim();
+    final bookCode = parts.sublist(2, chapterIdx).join('-').trim();
+    if (languageCode.isEmpty ||
+        bookId.isEmpty ||
+        chapterId.isEmpty ||
+        bookCode.isEmpty) {
+      return TimingExportMetadata.fallback;
+    }
+
+    return TimingExportMetadata(
+      languageCode: languageCode,
+      bookId: bookId,
+      bookCode: bookCode,
+      chapterId: chapterId,
+    );
+  }
+
+  static String generateTimingPayload(
+    List<Fragment> fragments,
+    TimingExportMetadata metadata,
+  ) {
+    final buffer = StringBuffer();
+    buffer.writeln('\\id ${metadata.bookCode}');
+    buffer.writeln('\\c ${metadata.chapterId}');
+    buffer.writeln('\\level phrase');
+
+    for (int i = 0; i < fragments.length; i++) {
+      final f = fragments[i];
+      final phraseId = _resolvePhraseId(f, i);
+      final start = _formatSeconds(f.realStart);
+      final end = _formatSeconds(f.realEnd);
+      buffer.writeln('$start\t$end\t$phraseId');
+    }
+
+    return buffer.toString();
+  }
+
+  static String defaultTimingFilenameFromSourcePath(String? sourcePath) {
+    if (sourcePath == null || sourcePath.trim().isEmpty) {
+      return 'BOOK-1-timing.txt';
+    }
+
+    final inputBase = p.basenameWithoutExtension(sourcePath);
+    final detected = _detectFilenameSeparator(inputBase);
+    final outputSep = detected == ' ' ? '-' : detected;
+    return '${inputBase}${outputSep}timing.txt';
+  }
+
+  static String defaultJsonFilenameFromSourcePath(String? sourcePath) {
+    if (sourcePath == null || sourcePath.trim().isEmpty) {
+      return 'alignment.json';
+    }
+    // Match UI-style behavior: start from source text base name.
+    final inputBase = p.basenameWithoutExtension(sourcePath);
+    if (inputBase.trim().isEmpty) return 'alignment.json';
+    return '$inputBase.json';
+  }
+
+  static CliOutputFormat resolveOutputFormat({
+    required String outputPath,
+    String? requestedFormat,
+  }) {
+    // Explicit --format always wins; extension inference is fallback behavior.
+    final normalized = requestedFormat?.trim().toLowerCase();
+    if (normalized == 'timing') return CliOutputFormat.timing;
+    if (normalized == 'json') return CliOutputFormat.json;
+
+    final ext = p.extension(outputPath).toLowerCase();
+    if (ext == '.txt') return CliOutputFormat.timing;
+    return CliOutputFormat.json;
+  }
+
+  static String normalizeOutputPathForFormat({
+    required String outputPath,
+    required CliOutputFormat format,
+  }) {
+    // Keep the saved filename extension aligned with the resolved format so
+    // callers never get JSON content in a .txt (or timing in a .json) file.
+    final expectedExtension =
+        format == CliOutputFormat.json ? '.json' : '.txt';
+    final currentExtension = p.extension(outputPath).toLowerCase();
+    if (currentExtension == expectedExtension) return outputPath;
+    return p.setExtension(outputPath, expectedExtension);
+  }
+
+  static String _resolvePhraseId(Fragment fragment, int index) {
+    final id = fragment.id?.trim();
+    if (id != null && id.isNotEmpty) return id;
+    return '${index + 1}';
+  }
+
+  static String _formatSeconds(double value) {
+    return value.toStringAsFixed(3).replaceFirst(RegExp(r'\.?0+$'), '');
+  }
+
+  static String _detectFilenameSeparator(String value) {
+    final dashCount = '-'.allMatches(value).length;
+    final underscoreCount = '_'.allMatches(value).length;
+    final spaceCount = ' '.allMatches(value).length;
+    if (dashCount == 0 && underscoreCount == 0 && spaceCount == 0) return '-';
+
+    final counts = {'-': dashCount, '_': underscoreCount, ' ': spaceCount};
+    final best = counts.entries.reduce((a, b) => a.value >= b.value ? a : b);
+    return best.key;
+  }
+
+  static List<String> _splitBySeparator(String value, String separator) {
+    if (separator == ' ') {
+      return value
+          .trim()
+          .split(RegExp(r'\s+'))
+          .where((p) => p.isNotEmpty)
+          .toList();
+    }
+    return value.split(separator).where((p) => p.isNotEmpty).toList();
+  }
+
+  static int _findChapterTokenIndex(List<String> parts) {
+    for (int i = parts.length - 1; i >= 0; i--) {
+      if (RegExp(r'^\d+$').hasMatch(parts[i].trim())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}

--- a/isochron_cli/technical_overview.md
+++ b/isochron_cli/technical_overview.md
@@ -354,7 +354,15 @@ This mode is often cleaner when adjacent fragments should meet in the middle of 
 
 ## Output Format
 
-The final JSON output contains one object per fragment:
+`isochron_cli` can now emit **JSON** or **timing text** from the same alignment run.
+
+Format resolution order:
+
+1. `--format json|timing` (if provided)
+2. inferred from `--output` extension (`.json` => JSON, `.txt` => timing)
+3. fallback to JSON
+
+### JSON output
 
 ```json
 [
@@ -367,15 +375,28 @@ The final JSON output contains one object per fragment:
 - `start` / `end` — timestamps in seconds, rounded to 3 decimal places.
 - `id` — included if the input text contained an explicit identifier.
 
+### Timing text output
+
+Timing text uses:
+
+- `\id <BOOK>`
+- `\c <CHAPTER>`
+- `\level phrase`
+- tab-separated rows: `<start>\t<end>\t<phraseId>`
+
+When a fragment `id` is missing, fallback IDs are numeric (`1`, `2`, `3`, ...).
+Metadata for `\id` and `\c` is parsed from the source text filename using the same logic shared with Flutter export.
+
 ---
 
 ## File Reference Summary
 
 | File | Role |
 |------|------|
-| `bin/isochron_cli.dart` | CLI entry point. Parses command-line flags, loads the dict file, calls `IsochronProcessor.process()`, and writes the JSON output. |
+| `bin/isochron_cli.dart` | CLI entry point. Parses command-line flags, resolves output format, runs `IsochronProcessor.process()`, and writes JSON or timing text output. |
 | `lib/src/core/isochron_processor.dart` | **Master pipeline** — orchestrates all 7 steps in order. The best place to understand the full flow. |
 | `lib/src/core/fragment.dart` | The `Fragment` data class. Carries text, anchor timings, and real timings through the entire pipeline. |
+| `lib/src/core/timing_export.dart` | Shared timing export core used by CLI and Flutter (metadata parsing, payload generation, output format resolution). |
 | `lib/src/core/text_parser.dart` | Splits the raw text file into `Fragment` objects (one per non-empty line). |
 | `lib/src/core/transliterator.dart` | Converts non-Latin characters to Latin equivalents using a user-provided dictionary. |
 | `lib/src/synthesis/anchor_generator.dart` | Calls eSpeak-ng to synthesize audio for each fragment, normalizes with FFmpeg, concatenates into one anchor WAV, and records anchor timings. |

--- a/isochron_cli/test/core/timing_export_test.dart
+++ b/isochron_cli/test/core/timing_export_test.dart
@@ -1,0 +1,185 @@
+import 'package:isochron_cli/isochron_cli.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TimingExport metadata parsing', () {
+    test('parses primary dash format', () {
+      final metadata = TimingExport.parseMetadataFromSourceFilename(
+        '/tmp/TH-01-GEN-01.txt',
+      );
+      expect(metadata.languageCode, 'TH');
+      expect(metadata.bookId, '01');
+      expect(metadata.bookCode, 'GEN');
+      expect(metadata.chapterId, '01');
+    });
+
+    test('parses underscore format with trailing suffix', () {
+      final metadata = TimingExport.parseMetadataFromSourceFilename(
+        '/tmp/grctr_071_MRK_01_read.txt',
+      );
+      expect(metadata.languageCode, 'grctr');
+      expect(metadata.bookId, '071');
+      expect(metadata.bookCode, 'MRK');
+      expect(metadata.chapterId, '01');
+    });
+
+    test('falls back on invalid source name', () {
+      final metadata = TimingExport.parseMetadataFromSourceFilename(
+        '/tmp/BADNAME.txt',
+      );
+      expect(metadata.languageCode, TimingExportMetadata.fallback.languageCode);
+      expect(metadata.bookId, TimingExportMetadata.fallback.bookId);
+      expect(metadata.bookCode, TimingExportMetadata.fallback.bookCode);
+      expect(metadata.chapterId, TimingExportMetadata.fallback.chapterId);
+    });
+  });
+
+  group('TimingExport payload generation', () {
+    test('uses tab-separated timing rows', () {
+      final fragments = [
+        Fragment(index: 0, id: 's1', text: 'line one')
+          ..setRealTiming(start: 2.132, end: 10.657),
+        Fragment(index: 1, id: '1a', text: 'line two')
+          ..setRealTiming(start: 10.657, end: 11.545),
+      ];
+      final payload = TimingExport.generateTimingPayload(
+        fragments,
+        const TimingExportMetadata(
+          languageCode: 'TH',
+          bookId: '01',
+          bookCode: 'GEN',
+          chapterId: '01',
+        ),
+      );
+
+      expect(
+        payload,
+        '\\id GEN\n'
+        '\\c 01\n'
+        '\\level phrase\n'
+        '2.132\t10.657\ts1\n'
+        '10.657\t11.545\t1a\n',
+      );
+    });
+
+    test('falls back to numeric IDs without s prefix', () {
+      final fragments = [
+        Fragment(index: 0, text: 'line one')
+          ..setRealTiming(start: 1.0, end: 2.0),
+        Fragment(index: 1, id: '', text: 'line two')
+          ..setRealTiming(start: 2.0, end: 3.0),
+      ];
+      final payload = TimingExport.generateTimingPayload(
+        fragments,
+        TimingExportMetadata.fallback,
+      );
+
+      expect(payload, contains('\n1\t2\t1\n'));
+      expect(payload, contains('\n2\t3\t2\n'));
+    });
+  });
+
+  group('TimingExport output naming and format resolution', () {
+    test('default json filename is derived from source text filename', () {
+      final name = TimingExport.defaultJsonFilenameFromSourcePath(
+        '/tmp/TH-01-GEN-01.txt',
+      );
+      expect(name, 'TH-01-GEN-01.json');
+    });
+
+    test('default json filename falls back when source is missing', () {
+      final name = TimingExport.defaultJsonFilenameFromSourcePath(null);
+      expect(name, 'alignment.json');
+    });
+
+    test('default timing filename uses detected underscore separator', () {
+      final name = TimingExport.defaultTimingFilenameFromSourcePath(
+        '/tmp/grctr_071_MRK_01_read.txt',
+      );
+      expect(name, 'grctr_071_MRK_01_read_timing.txt');
+    });
+
+    test('default timing filename normalizes spaces to dash', () {
+      final name = TimingExport.defaultTimingFilenameFromSourcePath(
+        '/tmp/grctr 071 MRK 01 read.txt',
+      );
+      expect(name, 'grctr 071 MRK 01 read-timing.txt');
+    });
+
+    test('resolveOutputFormat respects explicit format first', () {
+      final fmt = TimingExport.resolveOutputFormat(
+        outputPath: 'alignment.json',
+        requestedFormat: 'timing',
+      );
+      expect(fmt, CliOutputFormat.timing);
+    });
+
+    test('resolveOutputFormat keeps explicit json even with .txt output', () {
+      final fmt = TimingExport.resolveOutputFormat(
+        outputPath: 'alignment.txt',
+        requestedFormat: 'json',
+      );
+      expect(fmt, CliOutputFormat.json);
+    });
+
+    test('resolveOutputFormat infers from extension when not explicit', () {
+      expect(
+        TimingExport.resolveOutputFormat(outputPath: 'a.json'),
+        CliOutputFormat.json,
+      );
+      expect(
+        TimingExport.resolveOutputFormat(outputPath: 'a.txt'),
+        CliOutputFormat.timing,
+      );
+    });
+
+    test('resolveOutputFormat falls back to json for unknown extension', () {
+      final fmt = TimingExport.resolveOutputFormat(outputPath: 'a.out');
+      expect(fmt, CliOutputFormat.json);
+    });
+
+    test('normalizeOutputPathForFormat changes extension to match json', () {
+      final path = TimingExport.normalizeOutputPathForFormat(
+        outputPath: 'alignment.txt',
+        format: CliOutputFormat.json,
+      );
+      expect(path, 'alignment.json');
+    });
+
+    test('normalizeOutputPathForFormat changes extension to match timing', () {
+      final path = TimingExport.normalizeOutputPathForFormat(
+        outputPath: 'alignment.json',
+        format: CliOutputFormat.timing,
+      );
+      expect(path, 'alignment.txt');
+    });
+
+    test('normalizeOutputPathForFormat keeps matching extension unchanged', () {
+      final path = TimingExport.normalizeOutputPathForFormat(
+        outputPath: 'alignment.txt',
+        format: CliOutputFormat.timing,
+      );
+      expect(path, 'alignment.txt');
+    });
+
+    test('resolveEffectiveOutput centralizes format/path derivation', () {
+      final resolved = TimingExport.resolveEffectiveOutput(
+        explicitOutputPath: null,
+        requestedFormat: 'timing',
+        sourceTextPath: '/tmp/TH-01-GEN-01.txt',
+      );
+      expect(resolved.format, CliOutputFormat.timing);
+      expect(resolved.outputPath, 'TH-01-GEN-01-timing.txt');
+    });
+
+    test('resolveEffectiveOutput normalizes mismatched explicit extension', () {
+      final resolved = TimingExport.resolveEffectiveOutput(
+        explicitOutputPath: 'alignment.txt',
+        requestedFormat: 'json',
+        sourceTextPath: '/tmp/TH-01-GEN-01.txt',
+      );
+      expect(resolved.format, CliOutputFormat.json);
+      expect(resolved.outputPath, 'alignment.json');
+    });
+  });
+}

--- a/isochron_flutter/lib/services/export_service.dart
+++ b/isochron_flutter/lib/services/export_service.dart
@@ -1,0 +1,269 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:isochron_flutter/ui/models/project_model.dart';
+import 'package:path/path.dart' as p;
+
+class PhraseExportMetadata {
+  final String languageCode;
+  final String bookId;
+  final String bookCode;
+  final String chapterId;
+
+  const PhraseExportMetadata({
+    required this.languageCode,
+    required this.bookId,
+    required this.bookCode,
+    required this.chapterId,
+  });
+
+  static const PhraseExportMetadata fallback = PhraseExportMetadata(
+    languageCode: 'XX',
+    bookId: '00',
+    bookCode: 'BOOK',
+    chapterId: '1',
+  );
+}
+
+class ExportService {
+  /// Builds the "Export Combined CSV" payload for the whole project.
+  ///
+  /// This intentionally exports only alignments that are finalized enough for
+  /// downstream use (`done` / `reviewed`) to match existing product behavior.
+  static Future<String> buildCombinedCsv(Project project) async {
+    final exportablePairs = project.alignments
+        .where((p) => isPhraseExportableStatus(p.status))
+        .toList();
+    if (exportablePairs.isEmpty) return '';
+
+    final buffer = StringBuffer();
+    buffer.writeln('id,verse_id,recording_id,start,end');
+
+    for (final pair in exportablePairs) {
+      final entries = await _loadAlignmentEntries(project, pair);
+      if (entries.isEmpty) continue;
+
+      final audioAsset = project.audioPool
+          .where((a) => a.id == pair.audioAssetId)
+          .firstOrNull;
+      final displayTitle = audioAsset != null
+          ? p.basenameWithoutExtension(audioAsset.path)
+          : pair.id;
+
+      buffer.write(generateCsv(entries, displayTitle, includeHeader: false));
+    }
+
+    return buffer.toString();
+  }
+
+  /// Builds the phrase-timing payload for a single alignment pair.
+  ///
+  /// Returns `null` when export is not allowed (status) or when the
+  /// alignment JSON has no rows.
+  static Future<String?> buildPhraseTiming(Project project, AlignmentPair pair) async {
+    if (!canExportPhraseTiming(pair)) return null;
+
+    final entries = await _loadAlignmentEntries(project, pair);
+    if (entries.isEmpty) return null;
+
+    final textAsset = project.textPool
+        .where((a) => a.id == pair.textAssetId)
+        .firstOrNull;
+    final metadata = parsePhraseMetadataFromTextFilename(textAsset?.path);
+    return generatePhraseTiming(entries, metadata);
+  }
+
+  /// Serializes a list of alignment rows into the shared CSV schema.
+  static String generateCsv(
+    List<Map<String, dynamic>> entries,
+    String recordingId, {
+    bool includeHeader = true,
+  }) {
+    final buffer = StringBuffer();
+    if (includeHeader) {
+      buffer.writeln('id,verse_id,recording_id,start,end');
+    }
+
+    for (final e in entries) {
+      buffer.write('${e['index']},');
+      buffer.write('${e['id'] ?? ""},');
+      buffer.write('${_escape(recordingId)},');
+      buffer.write('${e['start']},');
+      buffer.write('${e['end']}\n');
+    }
+
+    return buffer.toString();
+  }
+
+  /// Serializes a list of alignment rows into phrase timing text format:
+  /// `\id`, `\c`, `\level phrase`, then `<start> <end> <phraseId>` rows.
+  static String generatePhraseTiming(
+    List<Map<String, dynamic>> entries,
+    PhraseExportMetadata metadata,
+  ) {
+    final buffer = StringBuffer();
+    buffer.writeln('\\id ${metadata.bookCode}');
+    buffer.writeln('\\c ${metadata.chapterId}');
+    buffer.writeln('\\level phrase');
+
+    for (int i = 0; i < entries.length; i++) {
+      final e = entries[i];
+      final phraseId = _resolvePhraseId(e, i);
+      final start = _formatSeconds(e['start']);
+      final end = _formatSeconds(e['end']);
+      buffer.writeln('$start\t$end\t$phraseId');
+    }
+
+    return buffer.toString();
+  }
+
+  /// Parses phrase metadata from a source text filename convention:
+  /// `LANG-BOOKID-BOOK-CHAPTERID.*`.
+  ///
+  /// Extension is ignored intentionally so both `.txt` and `.phrase` source
+  /// files can provide naming hints.
+  static PhraseExportMetadata parsePhraseMetadataFromTextFilename(String? textPath) {
+    if (textPath == null || textPath.trim().isEmpty) {
+      return PhraseExportMetadata.fallback;
+    }
+
+    final base = p.basenameWithoutExtension(textPath);
+    final separator = _detectFilenameSeparator(base);
+    final parts = _splitBySeparator(base, separator);
+    if (parts.length < 4) return PhraseExportMetadata.fallback;
+
+    final languageCode = parts[0].trim();
+    final bookId = parts[1].trim();
+    // Support optional trailing suffix tokens (e.g. "..._01_read") by taking
+    // the rightmost numeric token as chapter id.
+    final chapterIdx = _findChapterTokenIndex(parts);
+    if (chapterIdx <= 2) return PhraseExportMetadata.fallback;
+    final chapterId = parts[chapterIdx].trim();
+    final bookCode = parts.sublist(2, chapterIdx).join('-').trim();
+
+    if (languageCode.isEmpty || bookId.isEmpty || bookCode.isEmpty || chapterId.isEmpty) {
+      return PhraseExportMetadata.fallback;
+    }
+
+    return PhraseExportMetadata(
+      languageCode: languageCode,
+      bookId: bookId,
+      bookCode: bookCode,
+      chapterId: chapterId,
+    );
+  }
+
+  static String defaultPhraseTimingFilename(PhraseExportMetadata metadata) {
+    return '${metadata.languageCode}-${metadata.bookId}-${metadata.bookCode}-${metadata.chapterId}.txt';
+  }
+
+  static String defaultPhraseTimingFilenameForPair(
+    Project project,
+    AlignmentPair pair,
+  ) {
+    final textAsset = project.textPool
+        .where((a) => a.id == pair.textAssetId)
+        .firstOrNull;
+    if (textAsset == null || textAsset.path.trim().isEmpty) {
+      return defaultPhraseTimingFilename(PhraseExportMetadata.fallback);
+    }
+
+    final inputBase = p.basenameWithoutExtension(textAsset.path);
+    final detected = _detectFilenameSeparator(inputBase);
+    final outputSep = detected == ' ' ? '-' : detected;
+
+    // Timing exports are always plain text sidecars.
+    return '$inputBase${outputSep}timing.txt';
+  }
+
+  static String defaultCsvFilename(String projectName) {
+    return '${projectName.replaceAll(" ", "_")}_full.csv';
+  }
+
+  static bool isPhraseExportableStatus(AlignmentStatus status) {
+    return status == AlignmentStatus.done || status == AlignmentStatus.reviewed;
+  }
+
+  /// Phrase export is enabled when alignment status is finalized.
+  static bool canExportPhraseTiming(AlignmentPair pair) {
+    return isPhraseExportableStatus(pair.status);
+  }
+
+  /// User-facing tooltip reason for export button state.
+  /// Keep this centralized so toolbar and batch tiles stay consistent.
+  static String phraseExportTooltip(AlignmentPair pair) {
+    if (!isPhraseExportableStatus(pair.status)) {
+      return 'Export is available only for Done/Reviewed alignments';
+    }
+    if (canExportPhraseTiming(pair)) {
+      return 'Export phrase timing';
+    }
+    return 'Export unavailable';
+  }
+
+  static String _resolvePhraseId(Map<String, dynamic> entry, int index) {
+    final id = entry['id']?.toString().trim();
+    if (id != null && id.isNotEmpty) return id;
+    return '${index + 1}';
+  }
+
+  static String _formatSeconds(dynamic value) {
+    final asNum = value is num ? value.toDouble() : double.tryParse(value.toString()) ?? 0.0;
+    return asNum.toStringAsFixed(3).replaceFirst(RegExp(r'\.?0+$'), '');
+  }
+
+  static String _escape(String input) {
+    if (input.contains(',')) return '"$input"';
+    return input;
+  }
+
+  static String _detectFilenameSeparator(String value) {
+    final dashCount = '-'.allMatches(value).length;
+    final underscoreCount = '_'.allMatches(value).length;
+    final spaceCount = ' '.allMatches(value).length;
+    if (dashCount == 0 && underscoreCount == 0 && spaceCount == 0) return '-';
+
+    final counts = {'-': dashCount, '_': underscoreCount, ' ': spaceCount};
+    final best = counts.entries.reduce(
+      (a, b) => a.value >= b.value ? a : b,
+    );
+    return best.key;
+  }
+
+  static List<String> _splitBySeparator(String value, String separator) {
+    if (separator == ' ') {
+      return value
+          .trim()
+          .split(RegExp(r'\s+'))
+          .where((p) => p.isNotEmpty)
+          .toList();
+    }
+    return value.split(separator).where((p) => p.isNotEmpty).toList();
+  }
+
+  static int _findChapterTokenIndex(List<String> parts) {
+    for (int i = parts.length - 1; i >= 0; i--) {
+      if (RegExp(r'^\d+$').hasMatch(parts[i].trim())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /// Reads per-alignment JSON output persisted by the aligner.
+  static Future<List<Map<String, dynamic>>> _loadAlignmentEntries(
+    Project project,
+    AlignmentPair pair,
+  ) async {
+    final absJsonPath = pair.getAbsoluteOutputPath(project.directoryPath);
+    final file = File(absJsonPath);
+    if (!await file.exists()) return [];
+
+    final content = await file.readAsString();
+    final List<dynamic> jsonList = jsonDecode(content);
+    return jsonList
+        .whereType<Map>()
+        .map((e) => Map<String, dynamic>.from(e))
+        .toList();
+  }
+}

--- a/isochron_flutter/lib/services/export_service.dart
+++ b/isochron_flutter/lib/services/export_service.dart
@@ -1,29 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:isochron_cli/isochron_cli.dart';
 import 'package:isochron_flutter/ui/models/project_model.dart';
 import 'package:path/path.dart' as p;
-
-class PhraseExportMetadata {
-  final String languageCode;
-  final String bookId;
-  final String bookCode;
-  final String chapterId;
-
-  const PhraseExportMetadata({
-    required this.languageCode,
-    required this.bookId,
-    required this.bookCode,
-    required this.chapterId,
-  });
-
-  static const PhraseExportMetadata fallback = PhraseExportMetadata(
-    languageCode: 'XX',
-    bookId: '00',
-    bookCode: 'BOOK',
-    chapterId: '1',
-  );
-}
 
 class ExportService {
   /// Builds the "Export Combined CSV" payload for the whole project.
@@ -102,22 +82,12 @@ class ExportService {
   /// `\id`, `\c`, `\level phrase`, then `<start> <end> <phraseId>` rows.
   static String generatePhraseTiming(
     List<Map<String, dynamic>> entries,
-    PhraseExportMetadata metadata,
+    TimingExportMetadata metadata,
   ) {
-    final buffer = StringBuffer();
-    buffer.writeln('\\id ${metadata.bookCode}');
-    buffer.writeln('\\c ${metadata.chapterId}');
-    buffer.writeln('\\level phrase');
-
-    for (int i = 0; i < entries.length; i++) {
-      final e = entries[i];
-      final phraseId = _resolvePhraseId(e, i);
-      final start = _formatSeconds(e['start']);
-      final end = _formatSeconds(e['end']);
-      buffer.writeln('$start\t$end\t$phraseId');
-    }
-
-    return buffer.toString();
+    return TimingExport.generateTimingPayload(
+      _entriesToFragments(entries),
+      metadata,
+    );
   }
 
   /// Parses phrase metadata from a source text filename convention:
@@ -125,43 +95,13 @@ class ExportService {
   ///
   /// Extension is ignored intentionally so both `.txt` and `.phrase` source
   /// files can provide naming hints.
-  static PhraseExportMetadata parsePhraseMetadataFromTextFilename(
+  static TimingExportMetadata parsePhraseMetadataFromTextFilename(
     String? textPath,
   ) {
-    if (textPath == null || textPath.trim().isEmpty) {
-      return PhraseExportMetadata.fallback;
-    }
-
-    final base = p.basenameWithoutExtension(textPath);
-    final separator = _detectFilenameSeparator(base);
-    final parts = _splitBySeparator(base, separator);
-    if (parts.length < 4) return PhraseExportMetadata.fallback;
-
-    final languageCode = parts[0].trim();
-    final bookId = parts[1].trim();
-    // Support optional trailing suffix tokens (e.g. "..._01_read") by taking
-    // the rightmost numeric token as chapter id.
-    final chapterIdx = _findChapterTokenIndex(parts);
-    if (chapterIdx <= 2) return PhraseExportMetadata.fallback;
-    final chapterId = parts[chapterIdx].trim();
-    final bookCode = parts.sublist(2, chapterIdx).join('-').trim();
-
-    if (languageCode.isEmpty ||
-        bookId.isEmpty ||
-        bookCode.isEmpty ||
-        chapterId.isEmpty) {
-      return PhraseExportMetadata.fallback;
-    }
-
-    return PhraseExportMetadata(
-      languageCode: languageCode,
-      bookId: bookId,
-      bookCode: bookCode,
-      chapterId: chapterId,
-    );
+    return TimingExport.parseMetadataFromSourceFilename(textPath);
   }
 
-  static String defaultPhraseTimingFilename(PhraseExportMetadata metadata) {
+  static String defaultPhraseTimingFilename(TimingExportMetadata metadata) {
     return '${metadata.languageCode}-${metadata.bookId}-${metadata.bookCode}-${metadata.chapterId}.txt';
   }
 
@@ -172,16 +112,7 @@ class ExportService {
     final textAsset = project.textPool
         .where((a) => a.id == pair.textAssetId)
         .firstOrNull;
-    if (textAsset == null || textAsset.path.trim().isEmpty) {
-      return defaultPhraseTimingFilename(PhraseExportMetadata.fallback);
-    }
-
-    final inputBase = p.basenameWithoutExtension(textAsset.path);
-    final detected = _detectFilenameSeparator(inputBase);
-    final outputSep = detected == ' ' ? '-' : detected;
-
-    // Timing exports are always plain text sidecars.
-    return '$inputBase${outputSep}timing.txt';
+    return TimingExport.defaultTimingFilenameFromSourcePath(textAsset?.path);
   }
 
   static String defaultCsvFilename(String projectName) {
@@ -209,53 +140,9 @@ class ExportService {
     return 'Export unavailable';
   }
 
-  static String _resolvePhraseId(Map<String, dynamic> entry, int index) {
-    final id = entry['id']?.toString().trim();
-    if (id != null && id.isNotEmpty) return id;
-    return '${index + 1}';
-  }
-
-  static String _formatSeconds(dynamic value) {
-    final asNum = value is num
-        ? value.toDouble()
-        : double.tryParse(value.toString()) ?? 0.0;
-    return asNum.toStringAsFixed(3).replaceFirst(RegExp(r'\.?0+$'), '');
-  }
-
   static String _escape(String input) {
     if (input.contains(',')) return '"$input"';
     return input;
-  }
-
-  static String _detectFilenameSeparator(String value) {
-    final dashCount = '-'.allMatches(value).length;
-    final underscoreCount = '_'.allMatches(value).length;
-    final spaceCount = ' '.allMatches(value).length;
-    if (dashCount == 0 && underscoreCount == 0 && spaceCount == 0) return '-';
-
-    final counts = {'-': dashCount, '_': underscoreCount, ' ': spaceCount};
-    final best = counts.entries.reduce((a, b) => a.value >= b.value ? a : b);
-    return best.key;
-  }
-
-  static List<String> _splitBySeparator(String value, String separator) {
-    if (separator == ' ') {
-      return value
-          .trim()
-          .split(RegExp(r'\s+'))
-          .where((p) => p.isNotEmpty)
-          .toList();
-    }
-    return value.split(separator).where((p) => p.isNotEmpty).toList();
-  }
-
-  static int _findChapterTokenIndex(List<String> parts) {
-    for (int i = parts.length - 1; i >= 0; i--) {
-      if (RegExp(r'^\d+$').hasMatch(parts[i].trim())) {
-        return i;
-      }
-    }
-    return -1;
   }
 
   /// Reads per-alignment JSON output persisted by the aligner.
@@ -273,5 +160,22 @@ class ExportService {
         .whereType<Map>()
         .map((e) => Map<String, dynamic>.from(e))
         .toList();
+  }
+
+  static List<Fragment> _entriesToFragments(
+    List<Map<String, dynamic>> entries,
+  ) {
+    return entries.map((e) {
+      final fragment = Fragment(
+        index: (e['index'] as num?)?.toInt() ?? 0,
+        id: e['id']?.toString(),
+        text: e['text']?.toString() ?? '',
+      );
+      fragment.setRealTiming(
+        start: (e['start'] as num?)?.toDouble() ?? 0.0,
+        end: (e['end'] as num?)?.toDouble() ?? 0.0,
+      );
+      return fragment;
+    }).toList();
   }
 }

--- a/isochron_flutter/lib/services/export_service.dart
+++ b/isochron_flutter/lib/services/export_service.dart
@@ -60,7 +60,10 @@ class ExportService {
   ///
   /// Returns `null` when export is not allowed (status) or when the
   /// alignment JSON has no rows.
-  static Future<String?> buildPhraseTiming(Project project, AlignmentPair pair) async {
+  static Future<String?> buildPhraseTiming(
+    Project project,
+    AlignmentPair pair,
+  ) async {
     if (!canExportPhraseTiming(pair)) return null;
 
     final entries = await _loadAlignmentEntries(project, pair);
@@ -122,7 +125,9 @@ class ExportService {
   ///
   /// Extension is ignored intentionally so both `.txt` and `.phrase` source
   /// files can provide naming hints.
-  static PhraseExportMetadata parsePhraseMetadataFromTextFilename(String? textPath) {
+  static PhraseExportMetadata parsePhraseMetadataFromTextFilename(
+    String? textPath,
+  ) {
     if (textPath == null || textPath.trim().isEmpty) {
       return PhraseExportMetadata.fallback;
     }
@@ -141,7 +146,10 @@ class ExportService {
     final chapterId = parts[chapterIdx].trim();
     final bookCode = parts.sublist(2, chapterIdx).join('-').trim();
 
-    if (languageCode.isEmpty || bookId.isEmpty || bookCode.isEmpty || chapterId.isEmpty) {
+    if (languageCode.isEmpty ||
+        bookId.isEmpty ||
+        bookCode.isEmpty ||
+        chapterId.isEmpty) {
       return PhraseExportMetadata.fallback;
     }
 
@@ -208,7 +216,9 @@ class ExportService {
   }
 
   static String _formatSeconds(dynamic value) {
-    final asNum = value is num ? value.toDouble() : double.tryParse(value.toString()) ?? 0.0;
+    final asNum = value is num
+        ? value.toDouble()
+        : double.tryParse(value.toString()) ?? 0.0;
     return asNum.toStringAsFixed(3).replaceFirst(RegExp(r'\.?0+$'), '');
   }
 
@@ -224,9 +234,7 @@ class ExportService {
     if (dashCount == 0 && underscoreCount == 0 && spaceCount == 0) return '-';
 
     final counts = {'-': dashCount, '_': underscoreCount, ' ': spaceCount};
-    final best = counts.entries.reduce(
-      (a, b) => a.value >= b.value ? a : b,
-    );
+    final best = counts.entries.reduce((a, b) => a.value >= b.value ? a : b);
     return best.key;
   }
 

--- a/isochron_flutter/lib/ui/app_manager.dart
+++ b/isochron_flutter/lib/ui/app_manager.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:isochron_cli/isochron_cli.dart';
 import 'package:isochron_flutter/services/user_settings_service.dart';
+import 'package:isochron_flutter/utils/id_extraction.dart';
 import 'package:isochron_flutter/ui/models/project_model.dart';
 import 'package:just_waveform/just_waveform.dart';
 import 'package:macos_ui/macos_ui.dart';
@@ -226,12 +227,14 @@ class AppManager extends ValueNotifier<AppState> {
         for (var line in lines) {
           if (line.trim().isEmpty) continue;
 
-          final parts = line.trim().split(' ');
-          if (parts.length > 1) {
-            extractedIds.add(parts.first);
-            cleanLines.add(parts.sublist(1).join(' '));
+          final parsed = extractIdFromLine(line);
+          if (parsed.hasId) {
+            extractedIds.add(parsed.id);
+            debugPrint('[ALIGN] Found ID: ${parsed.id}');
+            cleanLines.add(parsed.content);
           } else {
             extractedIds.add("");
+            debugPrint('[ALIGN] No ID found for line: $line');
             cleanLines.add(line);
           }
         }

--- a/isochron_flutter/lib/ui/app_manager.dart
+++ b/isochron_flutter/lib/ui/app_manager.dart
@@ -230,11 +230,9 @@ class AppManager extends ValueNotifier<AppState> {
           final parsed = extractIdFromLine(line);
           if (parsed.hasId) {
             extractedIds.add(parsed.id);
-            debugPrint('[ALIGN] Found ID: ${parsed.id}');
             cleanLines.add(parsed.content);
           } else {
             extractedIds.add("");
-            debugPrint('[ALIGN] No ID found for line: $line');
             cleanLines.add(line);
           }
         }

--- a/isochron_flutter/lib/ui/workspace/workspace_screen.dart
+++ b/isochron_flutter/lib/ui/workspace/workspace_screen.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:isochron_flutter/services/alignment_service.dart';
+import 'package:isochron_flutter/utils/id_extraction.dart';
 import 'package:isochron_flutter/ui/app_manager.dart';
 import 'package:isochron_flutter/ui/models/project_model.dart';
 import 'package:macos_ui/macos_ui.dart';
@@ -436,10 +437,10 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
           final cleanLines = <String>[];
           for (var line in lines) {
             if (line.trim().isEmpty) continue;
-            final parts = line.trim().split(' ');
-            if (parts.length > 1) {
-              extractedIds.add(parts.first);
-              cleanLines.add(parts.sublist(1).join(' '));
+            final parsed = extractIdFromLine(line);
+            if (parsed.hasId) {
+              extractedIds.add(parsed.id);
+              cleanLines.add(parsed.content);
             } else {
               extractedIds.add("");
               cleanLines.add(line);

--- a/isochron_flutter/lib/ui/workspace/workspace_screen.dart
+++ b/isochron_flutter/lib/ui/workspace/workspace_screen.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:isochron_flutter/services/alignment_service.dart';
+import 'package:isochron_flutter/services/export_service.dart';
 import 'package:isochron_flutter/utils/id_extraction.dart';
 import 'package:isochron_flutter/ui/app_manager.dart';
 import 'package:isochron_flutter/ui/models/project_model.dart';
@@ -548,19 +549,9 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
   Future<void> _exportCsv() async {
     if (_project == null) return;
 
-    final exportablePairs = _project!.alignments
-        .where(
-          (p) =>
-              p.status == AlignmentStatus.done ||
-              p.status == AlignmentStatus.reviewed,
-        )
-        .toList();
-
-    if (exportablePairs.isEmpty) return;
-
     final String? outputFile = await FilePicker.saveFile(
       dialogTitle: 'Export Combined CSV',
-      fileName: '${_project!.name.replaceAll(" ", "_")}_full.csv',
+      fileName: ExportService.defaultCsvFilename(_project!.name),
       type: FileType.custom,
       allowedExtensions: ['csv'],
     );
@@ -568,39 +559,38 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
     if (outputFile == null) return;
 
     try {
-      final masterBuffer = StringBuffer();
-      masterBuffer.writeln('id,verse_id,recording_id,start,end');
-
-      for (var pair in exportablePairs) {
-        final absJsonPath = pair.getAbsoluteOutputPath(_project!.directoryPath);
-        final file = File(absJsonPath);
-
-        // Resolve the nice title
-        final audioAsset = _project!.audioPool
-            .where((a) => a.id == pair.audioAssetId)
-            .firstOrNull;
-        final displayTitle = audioAsset != null
-            ? p.basenameWithoutExtension(audioAsset.path)
-            : pair.id;
-
-        if (await file.exists()) {
-          final content = await file.readAsString();
-          final List<dynamic> jsonList = jsonDecode(content);
-
-          for (var j in jsonList) {
-            masterBuffer.write('${j['index']},');
-            masterBuffer.write('${j['id'] ?? ""},');
-            masterBuffer.write('$displayTitle,');
-            masterBuffer.write('${j['start']},');
-            masterBuffer.write('${j['end']}\n');
-          }
-        }
-      }
-
-      await File(outputFile).writeAsString(masterBuffer.toString());
+      // Workspace delegates export construction to ExportService so UI code only
+      // handles user interaction (save dialog + file write).
+      final payload = await ExportService.buildCombinedCsv(_project!);
+      if (payload.isEmpty) return;
+      await File(outputFile).writeAsString(payload);
     } catch (e) {
       debugPrint("CSV Export Error: $e");
     }
+  }
+
+  Future<void> _exportPhraseTimingForPair(AlignmentPair pair) async {
+    if (_project == null) return;
+    // Keep UI guard in sync with disabled buttons/tooltips for safety.
+    if (!ExportService.canExportPhraseTiming(pair)) return;
+    final defaultName = ExportService.defaultPhraseTimingFilenameForPair(
+      _project!,
+      pair,
+    );
+
+    final outputFile = await FilePicker.saveFile(
+      // Keep extension aligned with inferred default filename.
+      dialogTitle: 'Export Phrase Timing',
+      fileName: defaultName,
+      type: FileType.custom,
+      allowedExtensions: ['txt'],
+    );
+    if (outputFile == null) return;
+
+    // Service owns row loading + metadata parsing + phrase payload formatting.
+    final payload = await ExportService.buildPhraseTiming(_project!, pair);
+    if (payload == null || payload.isEmpty) return;
+    await File(outputFile).writeAsString(payload);
   }
 
   Future<bool> _requestCloseEditor() async {
@@ -720,6 +710,20 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
               }
             },
           ),
+          ToolBarIconButton(
+            label: 'Export Timing',
+            icon: MacosIcon(
+              CupertinoIcons.square_arrow_down,
+              color: ExportService.canExportPhraseTiming(_activePair!)
+                  ? MacosTheme.of(context).typography.body.color
+                  : CupertinoColors.systemGrey.withValues(alpha: 0.5),
+            ),
+            showLabel: true,
+            tooltipMessage: ExportService.phraseExportTooltip(_activePair!),
+            onPressed: ExportService.canExportPhraseTiming(_activePair!)
+                ? () => _exportPhraseTimingForPair(_activePair!)
+                : null,
+          ),
           const ToolBarSpacer(),
           CustomToolbarItem(
             inToolbarBuilder: (context) => MacosTooltip(
@@ -822,7 +826,9 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
             label: 'Import Text',
             icon: const MacosIcon(CupertinoIcons.add),
             showLabel: true,
-            onPressed: () => _importAsset('Text', ['txt'], _project!.textPool),
+            // Accept both `.txt` and `.phrases` transcript inputs.
+            onPressed: () =>
+                _importAsset('Text', ['txt', 'phrases'], _project!.textPool),
           ),
         );
         break;
@@ -902,6 +908,7 @@ class _WorkspaceScreenState extends State<WorkspaceScreen> {
             setState(() => _activePair = pair);
             await _homeManager.loadAlignmentPair(pair, _project!);
           },
+          onExportPhrase: _exportPhraseTimingForPair,
           onDelete: _deletePair,
         );
       case 2:
@@ -1505,6 +1512,7 @@ class _RealAlignmentList extends StatelessWidget {
   final AlignmentPair? selectedPair;
   final Function(AlignmentPair) onSelect;
   final Function(AlignmentPair) onOpenPair;
+  final Future<void> Function(AlignmentPair) onExportPhrase;
   final Function(AlignmentPair) onDelete;
 
   const _RealAlignmentList({
@@ -1513,6 +1521,7 @@ class _RealAlignmentList extends StatelessWidget {
     required this.selectedPair,
     required this.onSelect,
     required this.onOpenPair,
+    required this.onExportPhrase,
     required this.onDelete,
   });
 
@@ -1621,6 +1630,22 @@ class _RealAlignmentList extends StatelessWidget {
                                 ? CupertinoColors.activeGreen
                                 : CupertinoColors.systemYellow),
                     ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                MacosTooltip(
+                  message: ExportService.phraseExportTooltip(pair),
+                  useMousePosition: false,
+                  child: MacosIconButton(
+                    icon: MacosIcon(
+                      CupertinoIcons.square_arrow_down,
+                      color: ExportService.canExportPhraseTiming(pair)
+                          ? iconColor
+                          : CupertinoColors.systemGrey.withValues(alpha: 0.5),
+                    ),
+                    onPressed: ExportService.canExportPhraseTiming(pair)
+                        ? () => onExportPhrase(pair)
+                        : null,
                   ),
                 ),
                 const SizedBox(width: 8),

--- a/isochron_flutter/lib/utils/id_extraction.dart
+++ b/isochron_flutter/lib/utils/id_extraction.dart
@@ -1,0 +1,28 @@
+class ParsedIdLine {
+  final String id;
+  final String content;
+  final bool hasId;
+
+  const ParsedIdLine({
+    required this.id,
+    required this.content,
+    required this.hasId,
+  });
+}
+
+/// Extracts a leading ID from a transcript line when present.
+///
+/// Supports any whitespace separator (spaces, tabs, mixed whitespace).
+/// If no ID/content boundary is found, the original line is returned as content.
+ParsedIdLine extractIdFromLine(String line) {
+  final match = RegExp(r'^\s*(\S+)\s+(.+?)\s*$').firstMatch(line);
+  if (match == null) {
+    return ParsedIdLine(id: '', content: line, hasId: false);
+  }
+
+  return ParsedIdLine(
+    id: match.group(1) ?? '',
+    content: match.group(2) ?? '',
+    hasId: true,
+  );
+}

--- a/isochron_flutter/test/services/export_service_test.dart
+++ b/isochron_flutter/test/services/export_service_test.dart
@@ -1,0 +1,387 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isochron_flutter/services/export_service.dart';
+import 'package:isochron_flutter/ui/models/project_model.dart';
+
+void main() {
+  group('ExportService.generateCsv', () {
+    test('matches expected CSV format with header', () {
+      final entries = <Map<String, dynamic>>[
+        {'index': 0, 'id': '40001001', 'start': 2.132, 'end': 10.657},
+        {'index': 1, 'id': null, 'start': 10.657, 'end': 11.545},
+      ];
+
+      final csv = ExportService.generateCsv(entries, 'recordingA');
+      expect(
+        csv,
+        'id,verse_id,recording_id,start,end\n'
+        '0,40001001,recordingA,2.132,10.657\n'
+        '1,,recordingA,10.657,11.545\n',
+      );
+    });
+
+    test('supports headerless append mode', () {
+      final entries = <Map<String, dynamic>>[
+        {'index': 2, 'id': '40001003', 'start': 11.545, 'end': 12.200},
+      ];
+
+      final csv = ExportService.generateCsv(
+        entries,
+        'rec-2',
+        includeHeader: false,
+      );
+
+      expect(csv, '2,40001003,rec-2,11.545,12.2\n');
+    });
+
+    test('escapes recording IDs containing commas', () {
+      final entries = <Map<String, dynamic>>[
+        {'index': 1, 'id': 'v1', 'start': 0.0, 'end': 1.0},
+      ];
+
+      final csv = ExportService.generateCsv(entries, 'rec,with,comma');
+      expect(csv, contains('1,v1,"rec,with,comma",0.0,1.0'));
+    });
+  });
+
+  group('ExportService.parsePhraseMetadataFromTextFilename', () {
+    test('parses LANG-BOOKID-BOOK-CHAPTERID format', () {
+      final metadata = ExportService.parsePhraseMetadataFromTextFilename(
+        '/tmp/TH-01-GEN-01.txt',
+      );
+
+      expect(metadata.languageCode, 'TH');
+      expect(metadata.bookId, '01');
+      expect(metadata.bookCode, 'GEN');
+      expect(metadata.chapterId, '01');
+    });
+
+    test('supports book codes with dashes', () {
+      final metadata = ExportService.parsePhraseMetadataFromTextFilename(
+        '/tmp/en-19-1-KINGS-02.txt',
+      );
+
+      expect(metadata.languageCode, 'en');
+      expect(metadata.bookId, '19');
+      expect(metadata.bookCode, '1-KINGS');
+      expect(metadata.chapterId, '02');
+    });
+
+    test('falls back when parse is not possible', () {
+      final metadata = ExportService.parsePhraseMetadataFromTextFilename(
+        '/tmp/not-parseable.txt',
+      );
+      expect(metadata.languageCode, PhraseExportMetadata.fallback.languageCode);
+      expect(metadata.bookId, PhraseExportMetadata.fallback.bookId);
+      expect(metadata.bookCode, PhraseExportMetadata.fallback.bookCode);
+      expect(metadata.chapterId, PhraseExportMetadata.fallback.chapterId);
+    });
+
+    test('parses underscore variant with trailing suffix', () {
+      final metadata = ExportService.parsePhraseMetadataFromTextFilename(
+        '/tmp/grctr_071_MRK_01_read.txt',
+      );
+      expect(metadata.languageCode, 'grctr');
+      expect(metadata.bookId, '071');
+      expect(metadata.bookCode, 'MRK');
+      expect(metadata.chapterId, '01');
+    });
+
+    test('parses space-separated variant with trailing suffix', () {
+      final metadata = ExportService.parsePhraseMetadataFromTextFilename(
+        '/tmp/grctr 071 MRK 01 read.txt',
+      );
+      expect(metadata.languageCode, 'grctr');
+      expect(metadata.bookId, '071');
+      expect(metadata.bookCode, 'MRK');
+      expect(metadata.chapterId, '01');
+    });
+  });
+
+  group('ExportService.generatePhraseTiming', () {
+    test('emits the exact phrase timing structure', () {
+      final entries = <Map<String, dynamic>>[
+        {'index': 0, 'id': 's1', 'start': 2.132, 'end': 10.657},
+        {'index': 1, 'id': '1a', 'start': 10.657, 'end': 11.545},
+      ];
+      final metadata = ExportService.parsePhraseMetadataFromTextFilename(
+        '/tmp/TH-01-GEN-01.txt',
+      );
+
+      final phrase = ExportService.generatePhraseTiming(entries, metadata);
+      expect(
+        phrase,
+        '\\id GEN\n'
+        '\\c 01\n'
+        '\\level phrase\n'
+        '2.132\t10.657\ts1\n'
+        '10.657\t11.545\t1a\n',
+      );
+    });
+
+    test('falls back to <index+1> when id is missing', () {
+      final entries = <Map<String, dynamic>>[
+        {'index': 0, 'start': 2.1, 'end': 3.4},
+        {'index': 1, 'id': '', 'start': 3.4, 'end': 5.6},
+      ];
+
+      final phrase = ExportService.generatePhraseTiming(
+        entries,
+        PhraseExportMetadata.fallback,
+      );
+
+      expect(phrase, contains('\n2.1\t3.4\t1\n'));
+      expect(phrase, contains('\n3.4\t5.6\t2\n'));
+    });
+  });
+
+  group('ExportService helpers', () {
+    test('builds default filenames', () {
+      final phraseName = ExportService.defaultPhraseTimingFilename(
+        const PhraseExportMetadata(
+          languageCode: 'TH',
+          bookId: '01',
+          bookCode: 'GEN',
+          chapterId: '01',
+        ),
+      );
+      expect(phraseName, 'TH-01-GEN-01.txt');
+      expect(
+        ExportService.defaultCsvFilename('My Project Name'),
+        'My_Project_Name_full.csv',
+      );
+    });
+
+    test('status gating only allows done/reviewed', () {
+      expect(
+        ExportService.isPhraseExportableStatus(AlignmentStatus.done),
+        isTrue,
+      );
+      expect(
+        ExportService.isPhraseExportableStatus(AlignmentStatus.reviewed),
+        isTrue,
+      );
+      expect(
+        ExportService.isPhraseExportableStatus(AlignmentStatus.pending),
+        isFalse,
+      );
+      expect(
+        ExportService.isPhraseExportableStatus(AlignmentStatus.processing),
+        isFalse,
+      );
+      expect(
+        ExportService.isPhraseExportableStatus(AlignmentStatus.error),
+        isFalse,
+      );
+    });
+
+    test('combined phrase export gate requires valid status only', () {
+      final donePair = AlignmentPair(
+        id: 'done',
+        outputFilename: 'x.json',
+        status: AlignmentStatus.done,
+      );
+      final pendingPair = AlignmentPair(
+        id: 'pending',
+        outputFilename: 'x.json',
+        status: AlignmentStatus.pending,
+      );
+
+      expect(ExportService.canExportPhraseTiming(donePair), isTrue);
+      expect(ExportService.canExportPhraseTiming(pendingPair), isFalse);
+    });
+
+    test('tooltip reflects status-only enablement', () {
+      final donePair = AlignmentPair(
+        id: 'ok',
+        outputFilename: 'x.json',
+        status: AlignmentStatus.done,
+      );
+      final pendingPair = AlignmentPair(
+        id: 'bad_status',
+        outputFilename: 'x.json',
+        status: AlignmentStatus.pending,
+      );
+
+      expect(
+        ExportService.phraseExportTooltip(donePair),
+        'Export phrase timing',
+      );
+      expect(
+        ExportService.phraseExportTooltip(pendingPair),
+        'Export is available only for Done/Reviewed alignments',
+      );
+    });
+  });
+
+  group('ExportService orchestration', () {
+    late Directory tempDir;
+    late Project project;
+    late AlignmentPair donePair;
+    late AlignmentPair pendingPair;
+
+    Future<void> writePairOutput(
+      AlignmentPair pair,
+      List<Map<String, dynamic>> rows,
+    ) async {
+      final abs = pair.getAbsoluteOutputPath(project.directoryPath);
+      await File(abs).create(recursive: true);
+      await File(abs).writeAsString(jsonEncode(rows));
+    }
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('export_service_test_');
+
+      donePair = AlignmentPair(
+        id: 'pair_done',
+        audioAssetId: 'audio_1',
+        textAssetId: 'text_1',
+        outputFilename: 'done.json',
+        status: AlignmentStatus.done,
+      );
+      pendingPair = AlignmentPair(
+        id: 'pair_pending',
+        audioAssetId: 'audio_1',
+        textAssetId: 'text_2',
+        outputFilename: 'pending.json',
+        status: AlignmentStatus.pending,
+      );
+
+      project = Project(
+        id: 'proj1',
+        name: 'My Project',
+        directoryPath: tempDir.path,
+        audioPool: [ProjectAsset(id: 'audio_1', path: '/audio/rec01.wav')],
+        textPool: [
+          ProjectAsset(id: 'text_1', path: '/text/TH-01-GEN-01.txt'),
+          ProjectAsset(id: 'text_2', path: '/text/BADNAME.txt'),
+        ],
+        alignments: [donePair, pendingPair],
+      );
+
+      await writePairOutput(donePair, [
+        {'index': 0, 'id': 's1', 'start': 2.132, 'end': 10.657},
+        {'index': 1, 'id': '1a', 'start': 10.657, 'end': 11.545},
+      ]);
+      await writePairOutput(pendingPair, [
+        {'index': 0, 'id': 'p1', 'start': 0.0, 'end': 1.0},
+      ]);
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('buildCombinedCsv exports done/reviewed alignments only', () async {
+      final csv = await ExportService.buildCombinedCsv(project);
+
+      expect(csv, startsWith('id,verse_id,recording_id,start,end\n'));
+      expect(csv, contains('0,s1,rec01,2.132,10.657\n'));
+      expect(csv, contains('1,1a,rec01,10.657,11.545\n'));
+      expect(csv, isNot(contains('p1')));
+    });
+
+    test('buildPhraseTiming returns null for non-exportable status', () async {
+      final payload = await ExportService.buildPhraseTiming(project, pendingPair);
+      expect(payload, isNull);
+    });
+
+    test('buildPhraseTiming returns phrase payload for done pair', () async {
+      final payload = await ExportService.buildPhraseTiming(project, donePair);
+      expect(payload, isNotNull);
+      expect(payload!, startsWith('\\id GEN\n\\c 01\n\\level phrase\n'));
+      expect(payload, contains('2.132\t10.657\ts1\n'));
+    });
+
+    test('defaultPhraseTimingFilenameForPair uses parsed filename metadata', () {
+      final name = ExportService.defaultPhraseTimingFilenameForPair(
+        project,
+        donePair,
+      );
+      expect(name, 'TH-01-GEN-01-timing.txt');
+    });
+
+    test('defaultPhraseTimingFilenameForPair falls back on parse failure', () {
+      final name = ExportService.defaultPhraseTimingFilenameForPair(
+        project,
+        pendingPair,
+      );
+      expect(name, 'BADNAME-timing.txt');
+    });
+
+    test('buildCombinedCsv returns empty when no exportable alignments', () async {
+      pendingPair.status = AlignmentStatus.error;
+      donePair.status = AlignmentStatus.pending;
+
+      final csv = await ExportService.buildCombinedCsv(project);
+      expect(csv, isEmpty);
+    });
+
+    test('buildPhraseTiming still works for done non-.phrase input', () async {
+      donePair.textAssetId = 'text_2';
+      donePair.status = AlignmentStatus.done;
+
+      final payload = await ExportService.buildPhraseTiming(project, donePair);
+      expect(payload, isNotNull);
+      expect(payload!, startsWith('\\id BOOK\n\\c 1\n\\level phrase\n'));
+    });
+
+    test('default output naming preserves underscore separator', () {
+      final pair = AlignmentPair(
+        id: 'pair_underscore',
+        textAssetId: 'text_3',
+        outputFilename: 'u.json',
+        status: AlignmentStatus.done,
+      );
+      project.textPool.add(
+        ProjectAsset(id: 'text_3', path: '/text/grctr_071_MRK_01_read.txt'),
+      );
+
+      final name = ExportService.defaultPhraseTimingFilenameForPair(
+        project,
+        pair,
+      );
+      expect(name, 'grctr_071_MRK_01_read_timing.txt');
+    });
+
+    test('default output naming forces .txt extension even for .phrase input', () {
+      final pair = AlignmentPair(
+        id: 'pair_phrase_ext',
+        textAssetId: 'text_5',
+        outputFilename: 'p.json',
+        status: AlignmentStatus.done,
+      );
+      project.textPool.add(
+        ProjectAsset(id: 'text_5', path: '/text/TH-01-GEN-01.phrase'),
+      );
+
+      final name = ExportService.defaultPhraseTimingFilenameForPair(
+        project,
+        pair,
+      );
+      expect(name, 'TH-01-GEN-01-timing.txt');
+    });
+
+    test('default output naming normalizes space separator to dash', () {
+      final pair = AlignmentPair(
+        id: 'pair_space',
+        textAssetId: 'text_4',
+        outputFilename: 's.json',
+        status: AlignmentStatus.done,
+      );
+      project.textPool.add(
+        ProjectAsset(id: 'text_4', path: '/text/grctr 071 MRK 01 read.txt'),
+      );
+
+      final name = ExportService.defaultPhraseTimingFilenameForPair(
+        project,
+        pair,
+      );
+      expect(name, 'grctr 071 MRK 01 read-timing.txt');
+    });
+  });
+}

--- a/isochron_flutter/test/services/export_service_test.dart
+++ b/isochron_flutter/test/services/export_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:isochron_cli/isochron_cli.dart';
 import 'package:isochron_flutter/services/export_service.dart';
 import 'package:isochron_flutter/ui/models/project_model.dart';
 
@@ -73,10 +74,10 @@ void main() {
       final metadata = ExportService.parsePhraseMetadataFromTextFilename(
         '/tmp/not-parseable.txt',
       );
-      expect(metadata.languageCode, PhraseExportMetadata.fallback.languageCode);
-      expect(metadata.bookId, PhraseExportMetadata.fallback.bookId);
-      expect(metadata.bookCode, PhraseExportMetadata.fallback.bookCode);
-      expect(metadata.chapterId, PhraseExportMetadata.fallback.chapterId);
+      expect(metadata.languageCode, TimingExportMetadata.fallback.languageCode);
+      expect(metadata.bookId, TimingExportMetadata.fallback.bookId);
+      expect(metadata.bookCode, TimingExportMetadata.fallback.bookCode);
+      expect(metadata.chapterId, TimingExportMetadata.fallback.chapterId);
     });
 
     test('parses underscore variant with trailing suffix', () {
@@ -129,7 +130,7 @@ void main() {
 
       final phrase = ExportService.generatePhraseTiming(
         entries,
-        PhraseExportMetadata.fallback,
+        TimingExportMetadata.fallback,
       );
 
       expect(phrase, contains('\n2.1\t3.4\t1\n'));
@@ -140,7 +141,7 @@ void main() {
   group('ExportService helpers', () {
     test('builds default filenames', () {
       final phraseName = ExportService.defaultPhraseTimingFilename(
-        const PhraseExportMetadata(
+        const TimingExportMetadata(
           languageCode: 'TH',
           bookId: '01',
           bookCode: 'GEN',

--- a/isochron_flutter/test/services/export_service_test.dart
+++ b/isochron_flutter/test/services/export_service_test.dart
@@ -286,7 +286,10 @@ void main() {
     });
 
     test('buildPhraseTiming returns null for non-exportable status', () async {
-      final payload = await ExportService.buildPhraseTiming(project, pendingPair);
+      final payload = await ExportService.buildPhraseTiming(
+        project,
+        pendingPair,
+      );
       expect(payload, isNull);
     });
 
@@ -297,13 +300,16 @@ void main() {
       expect(payload, contains('2.132\t10.657\ts1\n'));
     });
 
-    test('defaultPhraseTimingFilenameForPair uses parsed filename metadata', () {
-      final name = ExportService.defaultPhraseTimingFilenameForPair(
-        project,
-        donePair,
-      );
-      expect(name, 'TH-01-GEN-01-timing.txt');
-    });
+    test(
+      'defaultPhraseTimingFilenameForPair uses parsed filename metadata',
+      () {
+        final name = ExportService.defaultPhraseTimingFilenameForPair(
+          project,
+          donePair,
+        );
+        expect(name, 'TH-01-GEN-01-timing.txt');
+      },
+    );
 
     test('defaultPhraseTimingFilenameForPair falls back on parse failure', () {
       final name = ExportService.defaultPhraseTimingFilenameForPair(
@@ -313,13 +319,16 @@ void main() {
       expect(name, 'BADNAME-timing.txt');
     });
 
-    test('buildCombinedCsv returns empty when no exportable alignments', () async {
-      pendingPair.status = AlignmentStatus.error;
-      donePair.status = AlignmentStatus.pending;
+    test(
+      'buildCombinedCsv returns empty when no exportable alignments',
+      () async {
+        pendingPair.status = AlignmentStatus.error;
+        donePair.status = AlignmentStatus.pending;
 
-      final csv = await ExportService.buildCombinedCsv(project);
-      expect(csv, isEmpty);
-    });
+        final csv = await ExportService.buildCombinedCsv(project);
+        expect(csv, isEmpty);
+      },
+    );
 
     test('buildPhraseTiming still works for done non-.phrase input', () async {
       donePair.textAssetId = 'text_2';
@@ -348,23 +357,26 @@ void main() {
       expect(name, 'grctr_071_MRK_01_read_timing.txt');
     });
 
-    test('default output naming forces .txt extension even for .phrase input', () {
-      final pair = AlignmentPair(
-        id: 'pair_phrase_ext',
-        textAssetId: 'text_5',
-        outputFilename: 'p.json',
-        status: AlignmentStatus.done,
-      );
-      project.textPool.add(
-        ProjectAsset(id: 'text_5', path: '/text/TH-01-GEN-01.phrase'),
-      );
+    test(
+      'default output naming forces .txt extension even for .phrase input',
+      () {
+        final pair = AlignmentPair(
+          id: 'pair_phrase_ext',
+          textAssetId: 'text_5',
+          outputFilename: 'p.json',
+          status: AlignmentStatus.done,
+        );
+        project.textPool.add(
+          ProjectAsset(id: 'text_5', path: '/text/TH-01-GEN-01.phrase'),
+        );
 
-      final name = ExportService.defaultPhraseTimingFilenameForPair(
-        project,
-        pair,
-      );
-      expect(name, 'TH-01-GEN-01-timing.txt');
-    });
+        final name = ExportService.defaultPhraseTimingFilenameForPair(
+          project,
+          pair,
+        );
+        expect(name, 'TH-01-GEN-01-timing.txt');
+      },
+    );
 
     test('default output naming normalizes space separator to dash', () {
       final pair = AlignmentPair(

--- a/isochron_flutter/test/utils/id_extraction_test.dart
+++ b/isochron_flutter/test/utils/id_extraction_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isochron_flutter/utils/id_extraction.dart';
+
+void main() {
+  group('extractIdFromLine', () {
+    test('extracts id with single-space delimiter', () {
+      final parsed = extractIdFromLine('40001001 In the beginning');
+      expect(parsed.hasId, isTrue);
+      expect(parsed.id, '40001001');
+      expect(parsed.content, 'In the beginning');
+    });
+
+    test('extracts id with tab delimiter', () {
+      final parsed = extractIdFromLine('40001001\tIn the beginning');
+      expect(parsed.hasId, isTrue);
+      expect(parsed.id, '40001001');
+      expect(parsed.content, 'In the beginning');
+    });
+
+    test('extracts id with mixed whitespace delimiter', () {
+      final parsed = extractIdFromLine('40001001 \t  In the beginning');
+      expect(parsed.hasId, isTrue);
+      expect(parsed.id, '40001001');
+      expect(parsed.content, 'In the beginning');
+    });
+
+    test('handles leading/trailing whitespace around id and content', () {
+      final parsed = extractIdFromLine('   40001001   In the beginning   ');
+      expect(parsed.hasId, isTrue);
+      expect(parsed.id, '40001001');
+      expect(parsed.content, 'In the beginning');
+    });
+
+    test('returns no id when line has only one token', () {
+      final parsed = extractIdFromLine('InTheBeginning');
+      expect(parsed.hasId, isFalse);
+      expect(parsed.id, '');
+      expect(parsed.content, 'InTheBeginning');
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces per-alignment timing-file export in the Flutter app and extends `isochron_cli` to export either JSON or timing text from the same alignment run. Both the UI and the CLI share one timing export core.

On the Flutter UI side, timing export is available on alignment-list tiles and the editor toolbar for a single alignment, gated to `done`/`reviewed` status with disabled-state tooltip messaging. 

| Before Alignment | After Alignment (and saving) |
|--------|--------|
| <img width="1754" height="294" alt="CleanShot 2026-05-07 at 17 46 19@2x" src="https://github.com/user-attachments/assets/8269a08b-0895-428a-bd73-713b944fcae9" /> | <img width="1386" height="278" alt="CleanShot 2026-05-07 at 17 43 15@2x" src="https://github.com/user-attachments/assets/7dee25e3-61cd-4f3d-a7b1-b3da900355a8" /> |
| <img width="1740" height="302" alt="CleanShot 2026-05-07 at 17 47 53@2x" src="https://github.com/user-attachments/assets/92cdc943-3a95-4b88-9f98-e2f4ecad0d9b" /> | <img width="1274" height="952" alt="CleanShot 2026-05-07 at 17 49 59@2x" src="https://github.com/user-attachments/assets/8215965e-4b46-4720-9f57-61834ff6e5eb" /> | 









Export naming follows the text-asset base name with a `timing` suffix and `.txt` output, and metadata (`\id`, `\c`) is parsed from source filename patterns with fallback defaults.

----

On the CLI side, `--output` remains the single destination and `--format` is optional.

Effective format resolves as `--format` > `--output` extension > JSON fallback, and output extension is normalized to match the resolved format. 

When `--output` is omitted, the filename is derived from the input text name using the same shared rules used by Flutter.

----

This also centralizes robust ID extraction during pre-processing (whitespace-tolerant parsing) and adds comprehensive tests/docs for Flutter UI behavior, CLI format resolution, filename handling, timing payload structure, and fallback IDs.

Closes #10 and #9.